### PR TITLE
Simplify and refactor formulae parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biodivine-hctl-model-checker"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Ondřej Huvar <xhuvar@fi.muni.cz>", "Samuel Pastva <sam.pastva@gmail.com>"]
 edition = "2021"
 description = "Library for symbolic HCTL model checking on partially defined Boolean networks."
@@ -31,4 +31,3 @@ biodivine-lib-param-bn = ">=0.4.3, <1.0.0"
 clap = { version = "4.1.4", features = ["derive"] }
 rand = "0.8.5"
 termcolor = "1.1.2"
-zip = "0.6.3"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Several interesting formulae are listed in the ```benchmark_formulae.txt``` file
 
 To create custom formulae, you can use any HCTL operators and many derived ones.
 We use the following syntax:
-* constants: `true`, `false`
+* constants: `true`/`True`/`1`, `false`/`False`/`0`
 * propositions: `alphanumeric characters and underscores` (e.g. `p_1`)
 * variables: `alphanumeric characters and underscores enclosed in "{}"` (e.g. `{x_1}`)
 * negation: `~`

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -4,7 +4,6 @@ use crate::evaluation::algorithm::{compute_steady_states, eval_node};
 use crate::evaluation::eval_info::EvalInfo;
 use crate::model_checking::{collect_unique_hctl_vars, get_extended_symbolic_graph};
 use crate::preprocessing::parser::parse_hctl_formula;
-use crate::preprocessing::tokenizer::try_tokenize_formula;
 use crate::preprocessing::utils::check_props_and_rename_vars;
 use crate::result_print::*;
 
@@ -30,11 +29,10 @@ pub fn analyse_formulae(
     let mut max_num_hctl_vars = 0;
     for formula in formulae {
         print_if_allowed(format!("Formula: {formula}"), print_op);
-        let tokens = try_tokenize_formula(formula)?;
-        let tree = parse_hctl_formula(&tokens)?;
+        let tree = parse_hctl_formula(formula.as_str())?;
         print_if_allowed(format!("Parsed formula:   {}", tree.subform_str), print_op);
 
-        let modified_tree = check_props_and_rename_vars(*tree, HashMap::new(), String::new(), bn)?;
+        let modified_tree = check_props_and_rename_vars(tree, HashMap::new(), String::new(), bn)?;
         let num_hctl_vars = collect_unique_hctl_vars(modified_tree.clone(), HashSet::new()).len();
         print_if_allowed(
             format!("Modified formula: {}", modified_tree.subform_str),

--- a/src/evaluation/algorithm.rs
+++ b/src/evaluation/algorithm.rs
@@ -270,14 +270,7 @@ mod tests {
     /// Test recognition of fixed-point pattern.
     fn test_fixed_point_pattern() {
         let tree = create_hybrid(
-            Box::new(create_unary(
-                Box::new(HctlTreeNode {
-                    subform_str: "{x}".to_string(),
-                    height: 0,
-                    node_type: NodeType::TerminalNode(Atomic::Var("x".to_string())),
-                }),
-                UnaryOp::Ax,
-            )),
+            create_unary(create_var_node("x".to_string()), UnaryOp::Ax),
             "x".to_string(),
             HybridOp::Bind,
         );
@@ -288,17 +281,10 @@ mod tests {
     /// Test recognition of attractor pattern.
     fn test_attractor_pattern() {
         let tree = create_hybrid(
-            Box::new(create_unary(
-                Box::new(create_unary(
-                    Box::new(HctlTreeNode {
-                        subform_str: "{x}".to_string(),
-                        height: 0,
-                        node_type: NodeType::TerminalNode(Atomic::Var("x".to_string())),
-                    }),
-                    UnaryOp::Ef,
-                )),
+            create_unary(
+                create_unary(create_var_node("x".to_string()), UnaryOp::Ef),
                 UnaryOp::Ag,
-            )),
+            ),
             "x".to_string(),
             HybridOp::Bind,
         );

--- a/src/evaluation/eval_info.rs
+++ b/src/evaluation/eval_info.rs
@@ -52,15 +52,13 @@ impl EvalInfo {
 mod tests {
     use crate::evaluation::eval_info::EvalInfo;
     use crate::preprocessing::parser::parse_hctl_formula;
-    use crate::preprocessing::tokenizer::try_tokenize_formula;
     use std::collections::HashMap;
 
     #[test]
     /// Test equivalent ways to generate EvalInfo object.
     fn test_eval_info_creation() {
         let formula = "!{x}: (AX {x} & AX {x})".to_string();
-        let tokens = try_tokenize_formula(formula).unwrap();
-        let syntax_tree = *parse_hctl_formula(&tokens).unwrap();
+        let syntax_tree = parse_hctl_formula(formula.as_str()).unwrap();
 
         let expected_duplicates = HashMap::from([("(Ax {var0})".to_string(), 1)]);
         let eval_info = EvalInfo::new(expected_duplicates.clone());

--- a/src/evaluation/mark_duplicate_subform.rs
+++ b/src/evaluation/mark_duplicate_subform.rs
@@ -175,9 +175,7 @@ mod tests {
     use crate::evaluation::mark_duplicate_subform::{
         mark_duplicates_canonized_multiple, mark_duplicates_canonized_single,
     };
-    use crate::preprocessing::parser::parse_hctl_formula;
-    use crate::preprocessing::tokenizer::try_tokenize_formula;
-    use crate::preprocessing::utils::check_props_and_rename_vars;
+    use crate::preprocessing::parser::parse_and_minimize_hctl_formula;
     use biodivine_lib_param_bn::BooleanNetwork;
     use std::collections::HashMap;
 
@@ -190,11 +188,8 @@ mod tests {
         // define any placeholder bn
         let bn = BooleanNetwork::try_from_bnet("v1, v1").unwrap();
 
-        let tokens = try_tokenize_formula(formula).unwrap();
-        let tree = parse_hctl_formula(&tokens).unwrap();
-        let modified_tree =
-            check_props_and_rename_vars(*tree, HashMap::new(), String::new(), &bn).unwrap();
-        let duplicates = mark_duplicates_canonized_single(&modified_tree);
+        let tree = parse_and_minimize_hctl_formula(&bn, formula.as_str()).unwrap();
+        let duplicates = mark_duplicates_canonized_single(&tree);
 
         assert_eq!(duplicates, expected_duplicates);
     }
@@ -212,12 +207,8 @@ mod tests {
         // define any placeholder bn
         let bn = BooleanNetwork::try_from_bnet("v1, v1").unwrap();
 
-        let tokens = try_tokenize_formula(formula).unwrap();
-        let tree = parse_hctl_formula(&tokens).unwrap();
-        let modified_tree =
-            check_props_and_rename_vars(*tree, HashMap::new(), String::new(), &bn).unwrap();
-        let duplicates = mark_duplicates_canonized_single(&modified_tree);
-
+        let tree = parse_and_minimize_hctl_formula(&bn, formula.as_str()).unwrap();
+        let duplicates = mark_duplicates_canonized_single(&tree);
         assert_eq!(duplicates, expected_duplicates);
     }
 
@@ -240,11 +231,8 @@ mod tests {
 
         let mut trees = Vec::new();
         for formula in formulae {
-            let tokens = try_tokenize_formula(formula).unwrap();
-            let tree = parse_hctl_formula(&tokens).unwrap();
-            let modified_tree =
-                check_props_and_rename_vars(*tree, HashMap::new(), String::new(), &bn).unwrap();
-            trees.push(modified_tree);
+            let tree = parse_and_minimize_hctl_formula(&bn, formula.as_str()).unwrap();
+            trees.push(tree);
         }
         let duplicates = mark_duplicates_canonized_multiple(&trees);
 

--- a/src/preprocessing/node.rs
+++ b/src/preprocessing/node.rs
@@ -73,34 +73,64 @@ impl fmt::Display for HctlTreeNode {
 }
 
 /// Create a hybrid node from given arguments.
-pub fn create_hybrid(child: Box<HctlTreeNode>, var: String, op: HybridOp) -> HctlTreeNode {
+pub fn create_hybrid(child: HctlTreeNode, var: String, op: HybridOp) -> HctlTreeNode {
     HctlTreeNode {
         subform_str: format!("({} {{{}}}: {})", op, var, child.subform_str),
         height: child.height + 1,
-        node_type: NodeType::HybridNode(op, var, child),
+        node_type: NodeType::HybridNode(op, var, Box::new(child)),
     }
 }
 
 /// Create an unary node from given arguments.
-pub fn create_unary(child: Box<HctlTreeNode>, op: UnaryOp) -> HctlTreeNode {
+pub fn create_unary(child: HctlTreeNode, op: UnaryOp) -> HctlTreeNode {
     HctlTreeNode {
         subform_str: format!("({} {})", op, child.subform_str),
         height: child.height + 1,
-        node_type: NodeType::UnaryNode(op, child),
+        node_type: NodeType::UnaryNode(op, Box::new(child)),
     }
 }
 
 /// Create a binary node from given arguments.
-pub fn create_binary(
-    left: Box<HctlTreeNode>,
-    right: Box<HctlTreeNode>,
-    op: BinaryOp,
-) -> HctlTreeNode {
+pub fn create_binary(left: HctlTreeNode, right: HctlTreeNode, op: BinaryOp) -> HctlTreeNode {
     HctlTreeNode {
         subform_str: format!("({} {} {})", left.subform_str, op, right.subform_str),
         height: cmp::max(left.height, right.height) + 1,
-        node_type: NodeType::BinaryNode(op, left, right),
+        node_type: NodeType::BinaryNode(op, Box::new(left), Box::new(right)),
     }
 }
 
-// TODO: make "create_var", "create_prop", and "create_constant" functions similar to previous
+/// Create a terminal `variable` node from given arguments.
+pub fn create_var_node(var_name: String) -> HctlTreeNode {
+    HctlTreeNode {
+        subform_str: format!("{{{var_name}}}"),
+        height: 0,
+        node_type: NodeType::TerminalNode(Atomic::Var(var_name)),
+    }
+}
+
+/// Create a terminal `proposition` node from given arguments.
+pub fn create_prop_node(prop_name: String) -> HctlTreeNode {
+    HctlTreeNode {
+        subform_str: format!("{{{prop_name}}}"),
+        height: 0,
+        node_type: NodeType::TerminalNode(Atomic::Prop(prop_name)),
+    }
+}
+
+/// Create a terminal `constant` node (true/false) from given arguments.
+/// `constant` should only be "true" or "false"
+pub fn create_constant_node(constant_val: bool) -> HctlTreeNode {
+    if constant_val {
+        HctlTreeNode {
+            subform_str: "True".to_string(),
+            height: 0,
+            node_type: NodeType::TerminalNode(Atomic::True),
+        }
+    } else {
+        HctlTreeNode {
+            subform_str: "False".to_string(),
+            height: 0,
+            node_type: NodeType::TerminalNode(Atomic::False),
+        }
+    }
+}

--- a/src/preprocessing/node.rs
+++ b/src/preprocessing/node.rs
@@ -111,7 +111,7 @@ pub fn create_var_node(var_name: String) -> HctlTreeNode {
 /// Create a terminal `proposition` node from given arguments.
 pub fn create_prop_node(prop_name: String) -> HctlTreeNode {
     HctlTreeNode {
-        subform_str: format!("{{{prop_name}}}"),
+        subform_str: prop_name.clone(),
         height: 0,
         node_type: NodeType::TerminalNode(Atomic::Prop(prop_name)),
     }

--- a/src/preprocessing/parser.rs
+++ b/src/preprocessing/parser.rs
@@ -1,4 +1,4 @@
-//! Contains functionality regarding parsing formula tokens into a syntax tree.
+//! Contains functionality regarding parsing formula (or formula tokens) into a syntax tree.
 //!
 //! The operator precedence is following (the lower, the stronger):
 //!  - unary operators (negation + temporal): 1
@@ -9,51 +9,78 @@
 
 use crate::preprocessing::node::*;
 use crate::preprocessing::operator_enums::*;
-use crate::preprocessing::tokenizer::Token;
+use crate::preprocessing::tokenizer::{try_tokenize_formula, HctlToken};
+use crate::preprocessing::utils::check_props_and_rename_vars;
+
+use biodivine_lib_param_bn::BooleanNetwork;
+
+use std::collections::HashMap;
+
+/// Parse an HCTL formula string representation into an actual formula tree.
+/// Basically a wrapper for tokenize+parse (used often for testing/debug purposes).
+/// NEEDS to call procedure for renaming variables to fully finish the preprocessing step.
+pub fn parse_hctl_formula(formula: &str) -> Result<HctlTreeNode, String> {
+    let tokens = try_tokenize_formula(formula.to_string())?;
+    let tree = parse_hctl_tokens(&tokens)?;
+    Ok(tree)
+}
+
+/// Parse an HCTL formula string representation into an actual formula tree with renamed (minimized)
+/// set of variables.
+/// Basically a wrapper for the whole preprocessing step (tokenize + parse + rename vars).
+pub fn parse_and_minimize_hctl_formula(
+    bn: &BooleanNetwork,
+    formula: &str,
+) -> Result<HctlTreeNode, String> {
+    let tokens = try_tokenize_formula(formula.to_string())?;
+    let tree = parse_hctl_tokens(&tokens)?;
+    let tree = check_props_and_rename_vars(tree, HashMap::new(), String::new(), bn)?;
+    Ok(tree)
+}
 
 /// Predicate for whether given token represents hybrid operator.
-fn is_hybrid(token: &Token) -> bool {
-    matches!(token, Token::Hybrid(_, _))
+fn is_hybrid(token: &HctlToken) -> bool {
+    matches!(token, HctlToken::Hybrid(_, _))
 }
 
 /// Predicate for whether given token represents temporal binary operator.
-fn is_binary_temporal(token: &Token) -> bool {
+fn is_binary_temporal(token: &HctlToken) -> bool {
     matches!(
         token,
-        Token::Binary(BinaryOp::Eu)
-            | Token::Binary(BinaryOp::Au)
-            | Token::Binary(BinaryOp::Ew)
-            | Token::Binary(BinaryOp::Aw)
+        HctlToken::Binary(BinaryOp::Eu)
+            | HctlToken::Binary(BinaryOp::Au)
+            | HctlToken::Binary(BinaryOp::Ew)
+            | HctlToken::Binary(BinaryOp::Aw)
     )
 }
 
 /// Predicate for whether given token represents unary operator.
-fn is_unary(token: &Token) -> bool {
-    matches!(token, Token::Unary(_))
+fn is_unary(token: &HctlToken) -> bool {
+    matches!(token, HctlToken::Unary(_))
 }
 
 /// Utility method to find the first occurrence of a specific token in the token tree.
-fn index_of_first(tokens: &[Token], token: Token) -> Option<usize> {
+fn index_of_first(tokens: &[HctlToken], token: HctlToken) -> Option<usize> {
     return tokens.iter().position(|t| *t == token);
 }
 
 /// Utility method to find the first occurrence of a hybrid operator in the token tree.
-fn index_of_first_hybrid(tokens: &[Token]) -> Option<usize> {
+fn index_of_first_hybrid(tokens: &[HctlToken]) -> Option<usize> {
     return tokens.iter().position(is_hybrid);
 }
 
 /// Utility method to find the first occurrence of a binary temporal operator in the token tree.
-fn index_of_first_binary_temp(tokens: &[Token]) -> Option<usize> {
+fn index_of_first_binary_temp(tokens: &[HctlToken]) -> Option<usize> {
     return tokens.iter().position(is_binary_temporal);
 }
 
 /// Utility method to find the first occurrence of an unary operator in the token tree.
-fn index_of_first_unary(tokens: &[Token]) -> Option<usize> {
+fn index_of_first_unary(tokens: &[HctlToken]) -> Option<usize> {
     return tokens.iter().position(is_unary);
 }
 
-/// Parse `tokens` in to a syntax tree using recursive steps.
-pub fn parse_hctl_formula(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String> {
+/// Parse `tokens` of HCTL formula into an abstract syntax tree using recursive steps.
+pub fn parse_hctl_tokens(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
     parse_1_hybrid(tokens)
 }
 
@@ -61,23 +88,21 @@ pub fn parse_hctl_formula(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String>
 /// Hybrid operator must not be immediately preceded by any other kind of operator.
 /// We only allow it to be preceded by another hybrid operator, or parentheses must be used.
 /// (things like "AF !{x}: ..." are forbidden, must be written in brackets as "AF (!{x}: ...)"
-fn parse_1_hybrid(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String> {
+fn parse_1_hybrid(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
     let hybrid_token = index_of_first_hybrid(tokens);
     Ok(if let Some(i) = hybrid_token {
         // perform check that hybrid operator is not preceded by other type of operators
-        if i > 0 && !matches!(&tokens[i - 1], Token::Hybrid(_, _)) {
+        if i > 0 && !matches!(&tokens[i - 1], HctlToken::Hybrid(_, _)) {
             return Err(format!(
                 "Hybrid operator can't be directly preceded by {}.",
                 &tokens[i - 1]
             ));
         }
         match &tokens[i] {
-            Token::Hybrid(op, var) => Box::new(create_hybrid(
-                parse_1_hybrid(&tokens[(i + 1)..])?,
-                var.clone(),
-                op.clone(),
-            )),
-            _ => Box::new(HctlTreeNode::new()), // This branch cant happen, but must result in same type
+            HctlToken::Hybrid(op, var) => {
+                create_hybrid(parse_1_hybrid(&tokens[(i + 1)..])?, var.clone(), op.clone())
+            }
+            _ => HctlTreeNode::new(), // This branch cant happen, but must result in same type
         }
     } else {
         parse_2_iff(tokens)?
@@ -85,86 +110,86 @@ fn parse_1_hybrid(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String> {
 }
 
 /// Recursive parsing step 2: extract `<=>` operators.
-fn parse_2_iff(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String> {
-    let iff_token = index_of_first(tokens, Token::Binary(BinaryOp::Iff));
+fn parse_2_iff(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
+    let iff_token = index_of_first(tokens, HctlToken::Binary(BinaryOp::Iff));
     Ok(if let Some(i) = iff_token {
-        Box::new(create_binary(
+        create_binary(
             parse_3_imp(&tokens[..i])?,
             parse_2_iff(&tokens[(i + 1)..])?,
             BinaryOp::Iff,
-        ))
+        )
     } else {
         parse_3_imp(tokens)?
     })
 }
 
 /// Recursive parsing step 3: extract `=>` operators.
-fn parse_3_imp(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String> {
-    let imp_token = index_of_first(tokens, Token::Binary(BinaryOp::Imp));
+fn parse_3_imp(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
+    let imp_token = index_of_first(tokens, HctlToken::Binary(BinaryOp::Imp));
     Ok(if let Some(i) = imp_token {
-        Box::new(create_binary(
+        create_binary(
             parse_4_or(&tokens[..i])?,
             parse_3_imp(&tokens[(i + 1)..])?,
             BinaryOp::Imp,
-        ))
+        )
     } else {
         parse_4_or(tokens)?
     })
 }
 
 /// Recursive parsing step 4: extract `|` operators.
-fn parse_4_or(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String> {
-    let or_token = index_of_first(tokens, Token::Binary(BinaryOp::Or));
+fn parse_4_or(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
+    let or_token = index_of_first(tokens, HctlToken::Binary(BinaryOp::Or));
     Ok(if let Some(i) = or_token {
-        Box::new(create_binary(
+        create_binary(
             parse_5_xor(&tokens[..i])?,
             parse_4_or(&tokens[(i + 1)..])?,
             BinaryOp::Or,
-        ))
+        )
     } else {
         parse_5_xor(tokens)?
     })
 }
 
 /// Recursive parsing step 5: extract `^` operators.
-fn parse_5_xor(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String> {
-    let xor_token = index_of_first(tokens, Token::Binary(BinaryOp::Xor));
+fn parse_5_xor(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
+    let xor_token = index_of_first(tokens, HctlToken::Binary(BinaryOp::Xor));
     Ok(if let Some(i) = xor_token {
-        Box::new(create_binary(
+        create_binary(
             parse_6_and(&tokens[..i])?,
             parse_5_xor(&tokens[(i + 1)..])?,
             BinaryOp::Xor,
-        ))
+        )
     } else {
         parse_6_and(tokens)?
     })
 }
 
 /// Recursive parsing step 6: extract `&` operators.
-fn parse_6_and(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String> {
-    let and_token = index_of_first(tokens, Token::Binary(BinaryOp::And));
+fn parse_6_and(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
+    let and_token = index_of_first(tokens, HctlToken::Binary(BinaryOp::And));
     Ok(if let Some(i) = and_token {
-        Box::new(create_binary(
+        create_binary(
             parse_7_binary_temp(&tokens[..i])?,
             parse_6_and(&tokens[(i + 1)..])?,
             BinaryOp::And,
-        ))
+        )
     } else {
         parse_7_binary_temp(tokens)?
     })
 }
 
 /// Recursive parsing step 7: extract binary temporal operators.
-fn parse_7_binary_temp(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String> {
+fn parse_7_binary_temp(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
     let binary_token = index_of_first_binary_temp(tokens);
     Ok(if let Some(i) = binary_token {
         match &tokens[i] {
-            Token::Binary(op) => Box::new(create_binary(
+            HctlToken::Binary(op) => create_binary(
                 parse_8_unary(&tokens[..i])?,
                 parse_7_binary_temp(&tokens[(i + 1)..])?,
                 op.clone(),
-            )),
-            _ => Box::new(HctlTreeNode::new()), // This branch cant happen, but must result in same type
+            ),
+            _ => HctlTreeNode::new(), // This branch cant happen, but must result in same type
         }
     } else {
         parse_8_unary(tokens)?
@@ -172,14 +197,12 @@ fn parse_7_binary_temp(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String> {
 }
 
 /// Recursive parsing step 8: extract unary temporal operators and negations.
-fn parse_8_unary(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String> {
+fn parse_8_unary(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
     let unary_token = index_of_first_unary(tokens);
     Ok(if let Some(i) = unary_token {
         match &tokens[i] {
-            Token::Unary(op) => {
-                Box::new(create_unary(parse_8_unary(&tokens[(i + 1)..])?, op.clone()))
-            }
-            _ => Box::new(HctlTreeNode::new()), // This branch cant happen, but must result in same type
+            HctlToken::Unary(op) => create_unary(parse_8_unary(&tokens[(i + 1)..])?, op.clone()),
+            _ => HctlTreeNode::new(), // This branch cant happen, but must result in same type
         }
     } else {
         parse_9_terminal_and_parentheses(tokens)?
@@ -187,43 +210,27 @@ fn parse_8_unary(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String> {
 }
 
 /// Recursive parsing step 9: extract terminals and recursively solve sub-formulae in parentheses.
-fn parse_9_terminal_and_parentheses(tokens: &[Token]) -> Result<Box<HctlTreeNode>, String> {
+fn parse_9_terminal_and_parentheses(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
     if tokens.is_empty() {
         Err("Expected formula, found nothing.".to_string())
     } else {
         if tokens.len() == 1 {
             // This should be name (var/prop) or a parenthesis group, everything else does not make sense.
             match &tokens[0] {
-                Token::Atom(Atomic::Prop(name)) => {
+                HctlToken::Atom(Atomic::Prop(name)) => {
                     return if name == "true" {
-                        Ok(Box::new(HctlTreeNode {
-                            subform_str: "True".to_string(),
-                            height: 0,
-                            node_type: NodeType::TerminalNode(Atomic::True),
-                        }))
+                        Ok(create_constant_node(true))
                     } else if name == "false" {
-                        Ok(Box::new(HctlTreeNode {
-                            subform_str: "False".to_string(),
-                            height: 0,
-                            node_type: NodeType::TerminalNode(Atomic::False),
-                        }))
+                        Ok(create_constant_node(false))
                     } else {
-                        Ok(Box::new(HctlTreeNode {
-                            subform_str: name.clone(),
-                            height: 0,
-                            node_type: NodeType::TerminalNode(Atomic::Prop(name.clone())),
-                        }))
+                        Ok(create_prop_node(name.clone()))
                     }
                 }
-                Token::Atom(Atomic::Var(name)) => {
-                    return Ok(Box::new(HctlTreeNode {
-                        subform_str: format!("{{{name}}}"),
-                        height: 0,
-                        node_type: NodeType::TerminalNode(Atomic::Var(name.clone())),
-                    }))
+                HctlToken::Atom(Atomic::Var(name)) => {
+                    return Ok(create_var_node(name.clone()))
                 }
                 // recursively solve sub-formulae in parentheses
-                Token::Tokens(inner) => return parse_hctl_formula(inner),
+                HctlToken::Tokens(inner) => return parse_hctl_tokens(inner),
                 _ => {} // otherwise, fall through to the error at the end.
             }
         }
@@ -236,59 +243,38 @@ mod tests {
     use crate::preprocessing::node::*;
     use crate::preprocessing::operator_enums::*;
     use crate::preprocessing::parser::parse_hctl_formula;
-    use crate::preprocessing::tokenizer::try_tokenize_formula;
 
     #[test]
     /// Test whether several valid HCTL formulae are parsed without causing errors.
     fn test_parse_valid_formulae() {
         let valid1 = "!{x}: AG EF {x}".to_string();
-        let tokens1 = try_tokenize_formula(valid1).unwrap();
-        assert!(parse_hctl_formula(&tokens1).is_ok());
+        assert!(parse_hctl_formula(valid1.as_str()).is_ok());
 
         let valid2 = "!{x}: 3{y}: (@{x}: ~{y} & AX {x}) & (@{y}: AX {y})".to_string();
-        let tokens2 = try_tokenize_formula(valid2).unwrap();
-        assert!(parse_hctl_formula(&tokens2).is_ok());
+        assert!(parse_hctl_formula(valid2.as_str()).is_ok());
 
         let valid3 = "3{x}: 3{y}: (@{x}: ~{y} & AX {x}) & (@{y}: AX {y}) & EF ({x} & (!{z}: AX {z})) & EF ({y} & (!{z}: AX {z})) & AX (EF ({x} & (!{z}: AX {z})) ^ EF ({y} & (!{z}: AX {z})))".to_string();
-        let tokens3 = try_tokenize_formula(valid3).unwrap();
-        assert!(parse_hctl_formula(&tokens3).is_ok());
+        assert!(parse_hctl_formula(valid3.as_str()).is_ok());
     }
 
     #[test]
     /// Test parsing of several valid HCTL formulae against expected results.
     fn compare_parser_with_expected() {
         let formula = "(false & p1)".to_string();
-        let tokens = try_tokenize_formula(formula).unwrap();
         let expected_tree = create_binary(
-            Box::new(HctlTreeNode {
-                subform_str: "False".to_string(),
-                height: 0,
-                node_type: NodeType::TerminalNode(Atomic::False),
-            }),
-            Box::new(HctlTreeNode {
-                subform_str: "p1".to_string(),
-                height: 0,
-                node_type: NodeType::TerminalNode(Atomic::Prop("p1".to_string())),
-            }),
+            create_constant_node(false),
+            create_prop_node("p1".to_string()),
             BinaryOp::And,
         );
-        assert_eq!(*parse_hctl_formula(&tokens).unwrap(), expected_tree);
+        assert_eq!(parse_hctl_formula(formula.as_str()).unwrap(), expected_tree);
 
         let formula = "!{x}: (AX {x})".to_string();
-        let tokens = try_tokenize_formula(formula).unwrap();
         let expected_tree = create_hybrid(
-            Box::new(create_unary(
-                Box::new(HctlTreeNode {
-                    subform_str: "{x}".to_string(),
-                    height: 0,
-                    node_type: NodeType::TerminalNode(Atomic::Var("x".to_string())),
-                }),
-                UnaryOp::Ax,
-            )),
+            create_unary(create_var_node("x".to_string()), UnaryOp::Ax),
             "x".to_string(),
             HybridOp::Bind,
         );
-        assert_eq!(*parse_hctl_formula(&tokens).unwrap(), expected_tree);
+        assert_eq!(parse_hctl_formula(formula.as_str()).unwrap(), expected_tree);
     }
 
     #[test]
@@ -307,8 +293,7 @@ mod tests {
         ];
 
         for formula in invalid_formulae {
-            let tokens = try_tokenize_formula(formula.to_string()).unwrap();
-            assert!(parse_hctl_formula(&tokens).is_err())
+            assert!(parse_hctl_formula(formula).is_err());
         }
     }
 }

--- a/src/preprocessing/tokenizer.rs
+++ b/src/preprocessing/tokenizer.rs
@@ -157,7 +157,8 @@ fn try_tokenize_recursive(
                     return Err("Expected '}'.".to_string());
                 }
             }
-            // proposition name
+            // proposition name or constant
+            // these 2 are NOT distinguished now but later during parsing
             c if is_valid_in_name(c) => {
                 let name = collect_name(input_chars)?;
                 output.push(HctlToken::Atom(Atomic::Prop(c.to_string() + &name)));

--- a/src/preprocessing/tokenizer.rs
+++ b/src/preprocessing/tokenizer.rs
@@ -8,25 +8,25 @@ use std::str::Chars;
 
 /// Enum of all possible tokens occurring in a HCTL formula string.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Token {
+pub enum HctlToken {
     Unary(UnaryOp),           // Unary operators: '~','EX','AX','EF','AF','EG','AG'
     Binary(BinaryOp),         // Binary operators: '&','|','^','=>','<=>','EU','AU','EW','AW'
     Hybrid(HybridOp, String), // Hybrid operator and its variable: '!', '@', '3', 'V'
     Atom(Atomic),             // Proposition, variable, or 'true'/'false' constant
-    Tokens(Vec<Token>),       // A block of tokens inside parentheses
+    Tokens(Vec<HctlToken>),   // A block of tokens inside parentheses
 }
 
 /// Try to tokenize given HCTL formula string.
 /// Wrapper for the recursive `try_tokenize_formula` function.
-pub fn try_tokenize_formula(formula: String) -> Result<Vec<Token>, String> {
+pub fn try_tokenize_formula(formula: String) -> Result<Vec<HctlToken>, String> {
     try_tokenize_recursive(&mut formula.chars().peekable(), true)
 }
 
-/// Process a peekable iterator of characters into a vector of `Token`s.
+/// Process a peekable iterator of characters into a vector of `HctlToken`s.
 fn try_tokenize_recursive(
     input_chars: &mut Peekable<Chars>,
     top_level: bool,
-) -> Result<Vec<Token>, String> {
+) -> Result<Vec<HctlToken>, String> {
     let mut output = Vec::new();
 
     while let Some(c) = input_chars.next() {
@@ -35,13 +35,13 @@ fn try_tokenize_recursive(
 
         match c {
             c if c.is_whitespace() => {} // skip whitespace
-            '~' => output.push(Token::Unary(UnaryOp::Not)),
-            '&' => output.push(Token::Binary(BinaryOp::And)),
-            '|' => output.push(Token::Binary(BinaryOp::Or)),
-            '^' => output.push(Token::Binary(BinaryOp::Xor)),
+            '~' => output.push(HctlToken::Unary(UnaryOp::Not)),
+            '&' => output.push(HctlToken::Binary(BinaryOp::And)),
+            '|' => output.push(HctlToken::Binary(BinaryOp::Or)),
+            '^' => output.push(HctlToken::Binary(BinaryOp::Xor)),
             '=' => {
                 if Some('>') == input_chars.next() {
-                    output.push(Token::Binary(BinaryOp::Imp));
+                    output.push(HctlToken::Binary(BinaryOp::Imp));
                 } else {
                     return Err("Expected '>' after '='.".to_string());
                 }
@@ -49,7 +49,7 @@ fn try_tokenize_recursive(
             '<' => {
                 if Some('=') == input_chars.next() {
                     if Some('>') == input_chars.next() {
-                        output.push(Token::Binary(BinaryOp::Iff));
+                        output.push(HctlToken::Binary(BinaryOp::Iff));
                     } else {
                         return Err("Expected '>' after '<='.".to_string());
                     }
@@ -67,7 +67,7 @@ fn try_tokenize_recursive(
                     if let Some(c3) = input_chars.peek() {
                         if is_valid_in_name(*c3) {
                             let name = collect_name(input_chars)?;
-                            output.push(Token::Atom(Atomic::Prop(
+                            output.push(HctlToken::Atom(Atomic::Prop(
                                 c.to_string() + c2.to_string().as_str() + &name,
                             )));
                             continue;
@@ -75,11 +75,11 @@ fn try_tokenize_recursive(
                     }
 
                     match c2 {
-                        'X' => output.push(Token::Unary(UnaryOp::Ex)),
-                        'F' => output.push(Token::Unary(UnaryOp::Ef)),
-                        'G' => output.push(Token::Unary(UnaryOp::Eg)),
-                        'U' => output.push(Token::Binary(BinaryOp::Eu)),
-                        'W' => output.push(Token::Binary(BinaryOp::Ew)),
+                        'X' => output.push(HctlToken::Unary(UnaryOp::Ex)),
+                        'F' => output.push(HctlToken::Unary(UnaryOp::Ef)),
+                        'G' => output.push(HctlToken::Unary(UnaryOp::Eg)),
+                        'U' => output.push(HctlToken::Binary(BinaryOp::Eu)),
+                        'W' => output.push(HctlToken::Binary(BinaryOp::Ew)),
                         _ => return Err(format!("Unexpected char '{c2}' after 'E'.")),
                     }
                 } else {
@@ -94,18 +94,18 @@ fn try_tokenize_recursive(
                     if let Some(c3) = input_chars.peek() {
                         if is_valid_in_name(*c3) {
                             let name = collect_name(input_chars)?;
-                            output.push(Token::Atom(Atomic::Prop(
+                            output.push(HctlToken::Atom(Atomic::Prop(
                                 c.to_string() + c2.to_string().as_str() + &name,
                             )));
                             continue;
                         }
                     }
                     match c2 {
-                        'X' => output.push(Token::Unary(UnaryOp::Ax)),
-                        'F' => output.push(Token::Unary(UnaryOp::Af)),
-                        'G' => output.push(Token::Unary(UnaryOp::Ag)),
-                        'U' => output.push(Token::Binary(BinaryOp::Au)),
-                        'W' => output.push(Token::Binary(BinaryOp::Aw)),
+                        'X' => output.push(HctlToken::Unary(UnaryOp::Ax)),
+                        'F' => output.push(HctlToken::Unary(UnaryOp::Af)),
+                        'G' => output.push(HctlToken::Unary(UnaryOp::Ag)),
+                        'U' => output.push(HctlToken::Binary(BinaryOp::Au)),
+                        'W' => output.push(HctlToken::Binary(BinaryOp::Aw)),
                         _ => return Err(format!("Unexpected char '{c2}' after 'A'.")),
                     }
                 } else {
@@ -115,24 +115,24 @@ fn try_tokenize_recursive(
             '!' => {
                 // we will collect the variable name via inside helper function
                 let name = collect_var_from_operator(input_chars, '!')?;
-                output.push(Token::Hybrid(HybridOp::Bind, name));
+                output.push(HctlToken::Hybrid(HybridOp::Bind, name));
             }
             '@' => {
                 // we will collect the variable name via inside helper function
                 let name = collect_var_from_operator(input_chars, '@')?;
-                output.push(Token::Hybrid(HybridOp::Jump, name));
+                output.push(HctlToken::Hybrid(HybridOp::Jump, name));
             }
             // "3" can be either exist quantifier or part of some proposition
             '3' if !is_valid_in_name_optional(input_chars.peek()) => {
                 // we will collect the variable name via inside helper function
                 let name = collect_var_from_operator(input_chars, '3')?;
-                output.push(Token::Hybrid(HybridOp::Exists, name));
+                output.push(HctlToken::Hybrid(HybridOp::Exists, name));
             }
             // "V" can be either forall quantifier or part of some proposition
             'V' if !is_valid_in_name_optional(input_chars.peek()) => {
                 // we will collect the variable name via inside helper function
                 let name = collect_var_from_operator(input_chars, 'V')?;
-                output.push(Token::Hybrid(HybridOp::Forall, name));
+                output.push(HctlToken::Hybrid(HybridOp::Forall, name));
             }
             ')' => {
                 return if !top_level {
@@ -144,7 +144,7 @@ fn try_tokenize_recursive(
             '(' => {
                 // start a nested token group
                 let token_group = try_tokenize_recursive(input_chars, false)?;
-                output.push(Token::Tokens(token_group));
+                output.push(HctlToken::Tokens(token_group));
             }
             // variable name
             '{' => {
@@ -152,7 +152,7 @@ fn try_tokenize_recursive(
                 if name.is_empty() {
                     return Err("Variable name can't be empty.".to_string());
                 }
-                output.push(Token::Atom(Atomic::Var(name)));
+                output.push(HctlToken::Atom(Atomic::Var(name)));
                 if Some('}') != input_chars.next() {
                     return Err("Expected '}'.".to_string());
                 }
@@ -160,7 +160,7 @@ fn try_tokenize_recursive(
             // proposition name
             c if is_valid_in_name(c) => {
                 let name = collect_name(input_chars)?;
-                output.push(Token::Atom(Atomic::Prop(c.to_string() + &name)));
+                output.push(HctlToken::Atom(Atomic::Prop(c.to_string() + &name)));
             }
             _ => return Err(format!("Unexpected char '{c}'.")),
         }
@@ -237,33 +237,33 @@ fn collect_var_from_operator(
     Ok(name)
 }
 
-impl fmt::Display for Token {
+impl fmt::Display for HctlToken {
     /// Display tokens for debug purposes.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Token::Unary(UnaryOp::Not) => write!(f, "~"),
-            Token::Unary(c) => write!(f, "{c:?}"), // unary temporal
-            Token::Binary(BinaryOp::And) => write!(f, "&"),
-            Token::Binary(BinaryOp::Or) => write!(f, "|"),
-            Token::Binary(BinaryOp::Xor) => write!(f, "^"),
-            Token::Binary(BinaryOp::Imp) => write!(f, "=>"),
-            Token::Binary(BinaryOp::Iff) => write!(f, "<=>"),
-            Token::Binary(c) => write!(f, "{c:?}"), // binary temporal
-            Token::Hybrid(op, var) => write!(f, "{op:?} {{{var}}}:"),
-            Token::Atom(Atomic::Prop(name)) => write!(f, "{name}"),
-            Token::Atom(Atomic::Var(name)) => write!(f, "{{{name}}}"),
-            Token::Atom(constant) => write!(f, "{constant:?}"),
-            Token::Tokens(_) => write!(f, "( TOKENS )"), // debug purposes only
+            HctlToken::Unary(UnaryOp::Not) => write!(f, "~"),
+            HctlToken::Unary(c) => write!(f, "{c:?}"), // unary temporal
+            HctlToken::Binary(BinaryOp::And) => write!(f, "&"),
+            HctlToken::Binary(BinaryOp::Or) => write!(f, "|"),
+            HctlToken::Binary(BinaryOp::Xor) => write!(f, "^"),
+            HctlToken::Binary(BinaryOp::Imp) => write!(f, "=>"),
+            HctlToken::Binary(BinaryOp::Iff) => write!(f, "<=>"),
+            HctlToken::Binary(c) => write!(f, "{c:?}"), // binary temporal
+            HctlToken::Hybrid(op, var) => write!(f, "{op:?} {{{var}}}:"),
+            HctlToken::Atom(Atomic::Prop(name)) => write!(f, "{name}"),
+            HctlToken::Atom(Atomic::Var(name)) => write!(f, "{{{name}}}"),
+            HctlToken::Atom(constant) => write!(f, "{constant:?}"),
+            HctlToken::Tokens(_) => write!(f, "( TOKENS )"), // debug purposes only
         }
     }
 }
 
 #[allow(dead_code)]
 /// Recursively print tokens.
-fn print_tokens_recursively(tokens: &Vec<Token>) {
+fn print_tokens_recursively(tokens: &Vec<HctlToken>) {
     for token in tokens {
         match token {
-            Token::Tokens(token_vec) => print_tokens_recursively(token_vec),
+            HctlToken::Tokens(token_vec) => print_tokens_recursively(token_vec),
             _ => print!("{token} "),
         }
     }
@@ -271,7 +271,7 @@ fn print_tokens_recursively(tokens: &Vec<Token>) {
 
 #[allow(dead_code)]
 /// Print the vector of tokens (for debug purposes).
-pub fn print_tokens(tokens: &Vec<Token>) {
+pub fn print_tokens(tokens: &Vec<HctlToken>) {
     print_tokens_recursively(tokens);
     println!();
 }
@@ -279,7 +279,7 @@ pub fn print_tokens(tokens: &Vec<Token>) {
 #[cfg(test)]
 mod tests {
     use crate::preprocessing::operator_enums::*;
-    use crate::preprocessing::tokenizer::{try_tokenize_formula, Token};
+    use crate::preprocessing::tokenizer::{try_tokenize_formula, HctlToken};
 
     #[test]
     /// Test tokenization process on several valid HCTL formulae.
@@ -289,10 +289,10 @@ mod tests {
         assert_eq!(
             tokens1_result.unwrap(),
             vec![
-                Token::Hybrid(HybridOp::Bind, "x".to_string()),
-                Token::Unary(UnaryOp::Ag),
-                Token::Unary(UnaryOp::Ef),
-                Token::Atom(Atomic::Var("x".to_string())),
+                HctlToken::Hybrid(HybridOp::Bind, "x".to_string()),
+                HctlToken::Unary(UnaryOp::Ag),
+                HctlToken::Unary(UnaryOp::Ef),
+                HctlToken::Atom(Atomic::Var("x".to_string())),
             ]
         );
 
@@ -301,17 +301,17 @@ mod tests {
         assert_eq!(
             tokens2_result.unwrap(),
             vec![
-                Token::Unary(UnaryOp::Af),
-                Token::Tokens(vec![
-                    Token::Hybrid(HybridOp::Bind, "x".to_string()),
-                    Token::Tokens(vec![
-                        Token::Unary(UnaryOp::Ax),
-                        Token::Tokens(vec![
-                            Token::Unary(UnaryOp::Not),
-                            Token::Atom(Atomic::Var("x".to_string())),
-                            Token::Binary(BinaryOp::And),
-                            Token::Unary(UnaryOp::Af),
-                            Token::Atom(Atomic::Var("x".to_string())),
+                HctlToken::Unary(UnaryOp::Af),
+                HctlToken::Tokens(vec![
+                    HctlToken::Hybrid(HybridOp::Bind, "x".to_string()),
+                    HctlToken::Tokens(vec![
+                        HctlToken::Unary(UnaryOp::Ax),
+                        HctlToken::Tokens(vec![
+                            HctlToken::Unary(UnaryOp::Not),
+                            HctlToken::Atom(Atomic::Var("x".to_string())),
+                            HctlToken::Binary(BinaryOp::And),
+                            HctlToken::Unary(UnaryOp::Af),
+                            HctlToken::Atom(Atomic::Var("x".to_string())),
                         ]),
                     ]),
                 ]),
@@ -323,21 +323,21 @@ mod tests {
         assert_eq!(
             tokens3_result.unwrap(),
             vec![
-                Token::Hybrid(HybridOp::Bind, "x".to_string()),
-                Token::Hybrid(HybridOp::Exists, "y".to_string()),
-                Token::Tokens(vec![
-                    Token::Hybrid(HybridOp::Jump, "x".to_string()),
-                    Token::Unary(UnaryOp::Not),
-                    Token::Atom(Atomic::Var("y".to_string())),
-                    Token::Binary(BinaryOp::And),
-                    Token::Unary(UnaryOp::Ax),
-                    Token::Atom(Atomic::Var("x".to_string())),
+                HctlToken::Hybrid(HybridOp::Bind, "x".to_string()),
+                HctlToken::Hybrid(HybridOp::Exists, "y".to_string()),
+                HctlToken::Tokens(vec![
+                    HctlToken::Hybrid(HybridOp::Jump, "x".to_string()),
+                    HctlToken::Unary(UnaryOp::Not),
+                    HctlToken::Atom(Atomic::Var("y".to_string())),
+                    HctlToken::Binary(BinaryOp::And),
+                    HctlToken::Unary(UnaryOp::Ax),
+                    HctlToken::Atom(Atomic::Var("x".to_string())),
                 ]),
-                Token::Binary(BinaryOp::And),
-                Token::Tokens(vec![
-                    Token::Hybrid(HybridOp::Jump, "y".to_string()),
-                    Token::Unary(UnaryOp::Ax),
-                    Token::Atom(Atomic::Var("y".to_string())),
+                HctlToken::Binary(BinaryOp::And),
+                HctlToken::Tokens(vec![
+                    HctlToken::Hybrid(HybridOp::Jump, "y".to_string()),
+                    HctlToken::Unary(UnaryOp::Ax),
+                    HctlToken::Atom(Atomic::Var("y".to_string())),
                 ]),
             ]
         );


### PR DESCRIPTION
This small PR mostly concerns parsing and tokenizing HCTL formulae.

- new wrapper functions `parse_hctl_formula` and `parse_and_minimize_hctl_formula` encapsulate all the preprocessing steps and make life easier
- nodes of HCTL syntax tree are now called `HctlTreeNode` for convenience
- it is now also easier to generate these `HctlTreeNode` objects - new functions for constructing terminal nodes are added, and all the constructors now take simple `HctlTreeNode` objects as "children" arguments instead of `Box<HctlTreeNode>`
- `False`, `0`, `True`, and `1` are now also considered valid constants in HCTL formulae
- some more code simplification, refactoring, and tests