### PR TITLE
Restructure and extend sanitizing functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biodivine-hctl-model-checker"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Ondřej Huvar <xhuvar@fi.muni.cz>", "Samuel Pastva <sam.pastva@gmail.com>"]
 edition = "2021"
 description = "Library for symbolic HCTL model checking on partially defined Boolean networks."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biodivine-hctl-model-checker"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Ondřej Huvar <xhuvar@fi.muni.cz>", "Samuel Pastva <sam.pastva@gmail.com>"]
 edition = "2021"
 description = "Library for symbolic HCTL model checking on partially defined Boolean networks."

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -2,7 +2,7 @@
 
 use crate::evaluation::algorithm::{compute_steady_states, eval_node};
 use crate::evaluation::eval_info::EvalInfo;
-use crate::model_checking::{collect_unique_hctl_vars, get_extended_symbolic_graph};
+use crate::mc_utils::{collect_unique_hctl_vars, get_extended_symbolic_graph};
 use crate::preprocessing::parser::parse_hctl_formula;
 use crate::preprocessing::utils::check_props_and_rename_vars;
 use crate::result_print::*;

--- a/src/evaluation/mod.rs
+++ b/src/evaluation/mod.rs
@@ -3,6 +3,7 @@
 pub mod algorithm;
 pub mod eval_info;
 pub mod mark_duplicate_subform;
+pub mod sanitizing;
 
 mod canonization;
 mod hctl_operators_evaluation;

--- a/src/evaluation/sanitizing.rs
+++ b/src/evaluation/sanitizing.rs
@@ -1,0 +1,104 @@
+//! Contains operations to sanitize bdds of their additional symbolic variables,
+//! making them compatible with remaining biodivine libraries.
+
+use biodivine_lib_bdd::Bdd;
+use biodivine_lib_param_bn::symbolic_async_graph::{
+    GraphColoredVertices, SymbolicAsyncGraph, SymbolicContext,
+};
+use std::collections::HashMap;
+use std::io::Write;
+
+/// Turns a BDD that is a valid representation of coloured state set in the
+/// `model_checking_context` into a BDD of the equivalent set in the `canonical_context`.
+///
+/// The method assumes that variables and parameters are ordered equivalently, they are just
+/// augmented with extra model checking variables that are unused in the original BDD.
+fn sanitize_bdd(
+    model_checking_context: &SymbolicContext,
+    canonical_context: &SymbolicContext,
+    bdd: &Bdd,
+) -> Bdd {
+    // First, build a map that translates a "model checking" symbolic variable
+    // into an equivalent "canonical" variable.
+    let mut variable_map = HashMap::new();
+    let mc_state_variables = model_checking_context.state_variables().iter();
+    let mc_param_variables = model_checking_context.parameter_variables().iter();
+    for mc_var in mc_state_variables.chain(mc_param_variables) {
+        let var_name = model_checking_context.bdd_variable_set().name_of(*mc_var);
+        let c_var = canonical_context
+            .bdd_variable_set()
+            .var_by_name(&var_name)
+            .expect("Mismatch in model variables.");
+        variable_map.insert(*mc_var, c_var);
+    }
+
+    // Then verify that the ordering of these variables is the same across both contexts.
+    let mut mc_variables_sorted = Vec::from_iter(variable_map.keys().cloned());
+    mc_variables_sorted.sort();
+    let mut c_variables_sorted = Vec::from_iter(variable_map.values().cloned());
+    c_variables_sorted.sort();
+    for (mc, c) in mc_variables_sorted.iter().zip(c_variables_sorted.iter()) {
+        assert_eq!(
+            variable_map.get(mc),
+            Some(c),
+            "Mismatch in variable ordering."
+        );
+    }
+
+    // Now we know it is actually safe to translate the BDD.
+
+    // Now we have to do a very dumb thing to translate a BDD variable to its actual "raw index".
+    // Sadly there isn't a nicer way to do this in lib-bdd right now.
+    let mut variable_map = variable_map
+        .into_iter()
+        .map(|(a, b)| (format!("{a}"), format!("{b}")))
+        .collect::<HashMap<_, _>>();
+    // BDD terminal nodes contain information about the number of variables instead of a variable id.
+    // We have to map this information too in the new BDD.
+    variable_map.insert(
+        format!("{}", model_checking_context.bdd_variable_set().num_vars()),
+        format!("{}", canonical_context.bdd_variable_set().num_vars()),
+    );
+
+    let mc_string = bdd.to_string();
+    let mut c_string: Vec<u8> = Vec::new();
+    write!(c_string, "|").unwrap();
+
+    for mc_node in mc_string.split('|') {
+        if mc_node.is_empty() {
+            // First and last item will be empty because there is an additional separator
+            // at the beginning/end of the string.
+            continue;
+        }
+        let mut node_data = mc_node.split(',');
+        // Low/high links remain the same, but the variable ID is translated.
+        let node_var = node_data.next().unwrap();
+        let node_low = node_data.next().unwrap();
+        let node_high = node_data.next().unwrap();
+        let new_node_var = variable_map
+            .get(node_var)
+            .expect("Model checking BDD is using unexpected variables.");
+        write!(c_string, "{new_node_var},{node_low},{node_high}|").unwrap();
+    }
+
+    Bdd::from_string(&String::from_utf8(c_string).unwrap())
+}
+
+/// Sanitize underlying BDD of a given coloured state set by removing its symbolic variables
+/// that were used for representing HCTL state-variables.
+///
+/// The method assumes that variables and parameters are ordered equivalently, they are just
+/// augmented with extra model checking variables that are unused in the original BDD.
+pub fn sanitize_graph_colored_vertices(
+    stg: &SymbolicAsyncGraph,
+    colored_vertices: &GraphColoredVertices,
+) -> GraphColoredVertices {
+    let canonical_bn = stg.as_network();
+    let canonical_context = SymbolicContext::new(canonical_bn).unwrap();
+    let sanitized_result_bdd = sanitize_bdd(
+        stg.symbolic_context(),
+        &canonical_context,
+        colored_vertices.as_bdd(),
+    );
+    GraphColoredVertices::new(sanitized_result_bdd, &canonical_context)
+}

--- a/src/evaluation/sanitizing.rs
+++ b/src/evaluation/sanitizing.rs
@@ -105,7 +105,7 @@ pub fn sanitize_colored_vertices(
 mod tests {
     use crate::evaluation::algorithm::compute_steady_states;
     use crate::evaluation::sanitizing::sanitize_colored_vertices;
-    use crate::model_checking::get_extended_symbolic_graph;
+    use crate::mc_utils::get_extended_symbolic_graph;
     use biodivine_lib_param_bn::symbolic_async_graph::SymbolicAsyncGraph;
     use biodivine_lib_param_bn::BooleanNetwork;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod analysis;
 pub mod evaluation;
+pub mod mc_utils;
 pub mod model_checking;
 pub mod preprocessing;
 pub mod result_print;

--- a/src/mc_utils.rs
+++ b/src/mc_utils.rs
@@ -1,0 +1,66 @@
+//! Model checking utilities such as generating extended STG or checking STG for variable support.
+
+use crate::preprocessing::node::{HctlTreeNode, NodeType};
+use crate::preprocessing::operator_enums::HybridOp;
+
+use biodivine_lib_param_bn::symbolic_async_graph::{SymbolicAsyncGraph, SymbolicContext};
+use biodivine_lib_param_bn::BooleanNetwork;
+
+use std::collections::{HashMap, HashSet};
+
+/// Create an extended symbolic graph that supports the number of needed HCTL variables.
+pub fn get_extended_symbolic_graph(
+    bn: &BooleanNetwork,
+    num_hctl_vars: u16,
+) -> Result<SymbolicAsyncGraph, String> {
+    // for each BN var, `num_hctl_vars` new BDD vars must be created
+    let mut map_num_vars = HashMap::new();
+    for bn_var in bn.variables() {
+        map_num_vars.insert(bn_var, num_hctl_vars);
+    }
+    let context = SymbolicContext::with_extra_state_variables(bn, &map_num_vars)?;
+    let unit = context.mk_constant(true);
+
+    SymbolicAsyncGraph::with_custom_context(bn.clone(), context, unit)
+}
+
+/// Compute the set of all uniquely named HCTL variables in the formula tree.
+/// Variable names are collected from three quantifiers: bind, exists, forall (which is sufficient,
+/// as the formula must not contain free variables).
+pub fn collect_unique_hctl_vars(
+    formula_tree: HctlTreeNode,
+    mut seen_vars: HashSet<String>,
+) -> HashSet<String> {
+    match formula_tree.node_type {
+        NodeType::TerminalNode(_) => {}
+        NodeType::UnaryNode(_, child) => {
+            seen_vars.extend(collect_unique_hctl_vars(*child, seen_vars.clone()));
+        }
+        NodeType::BinaryNode(_, left, right) => {
+            seen_vars.extend(collect_unique_hctl_vars(*left, seen_vars.clone()));
+            seen_vars.extend(collect_unique_hctl_vars(*right, seen_vars.clone()));
+        }
+        // collect variables from exist and binder nodes
+        NodeType::HybridNode(op, var_name, child) => {
+            match op {
+                HybridOp::Bind | HybridOp::Exists | HybridOp::Forall => {
+                    seen_vars.insert(var_name); // we do not care whether insert is successful
+                }
+                _ => {}
+            }
+            seen_vars.extend(collect_unique_hctl_vars(*child, seen_vars.clone()));
+        }
+    }
+    seen_vars
+}
+
+/// Check that extended symbolic graph's BDD supports enough extra variables for the computation.
+/// There must be `num_hctl_vars` extra symbolic BDD vars for each BN variable.
+pub fn check_hctl_var_support(stg: &SymbolicAsyncGraph, num_hctl_vars: usize) -> bool {
+    for bn_var in stg.as_network().variables() {
+        if num_hctl_vars > stg.symbolic_context().extra_state_variables(bn_var).len() {
+            return false;
+        }
+    }
+    true
+}

--- a/src/model_checking.rs
+++ b/src/model_checking.rs
@@ -198,6 +198,7 @@ pub fn model_check_formula_dirty(
 /// some formulae, but incorrect for others - it is thus an UNSAFE optimisation - only use it
 /// if you are sure everything will work fine.
 /// This must NOT be used for formulae containing `!{x}:AX{x}` sub-formulae.
+/// Also, does not sanitize results.
 pub fn model_check_formula_unsafe_ex(
     formula: String,
     stg: &SymbolicAsyncGraph,
@@ -213,8 +214,7 @@ pub fn model_check_formula_unsafe_ex(
 
     // do not consider self-loops during EX computation (UNSAFE optimisation)
     let result = eval_node(tree, stg, &mut eval_info, &stg.mk_empty_vertices());
-    // sanitize resulting BDD
-    Ok(sanitize_colored_vertices(stg, &result))
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/src/model_checking.rs
+++ b/src/model_checking.rs
@@ -33,13 +33,7 @@ pub fn model_check_multiple_trees_dirty(
             &self_loop_states,
         ));
     }
-
-    // sanitize the results' bdds - get rid of additional bdd vars used for HCTL vars
-    let sanitized_results: Vec<GraphColoredVertices> = results
-        .iter()
-        .map(|x| sanitize_colored_vertices(stg, x))
-        .collect();
-    Ok(sanitized_results)
+    Ok(results)
 }
 
 /// Perform the model checking for the list of HCTL syntax trees on GIVEN graph.


### PR DESCRIPTION
- Move utility functions to a separate module.
- Add "dirty" versions for each model checking function. These versions do not employ sanitization and are helpful for some tasks with BN sketches (when we need to utilize the whole symbolic context).