### PR TITLE
Add support for wild-card propositions

### DIFF
--- a/.githooks/README.txt
+++ b/.githooks/README.txt
@@ -1,3 +1,0 @@
-To globally enable githooks, run:
-
-git config core.hooksPath .githooks

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Runs automatic formatting and tests
-
-exec cargo fmt -- --check
-exec cargo build --all-features
-exec cargo test --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Setup cargo-tarpaulin.
         run: cargo install cargo-tarpaulin
       - name: Run tarpaulin to compute coverage.
-        run: cargo tarpaulin --verbose --lib --examples --all-features --out Xml
+        run: cargo tarpaulin --verbose --lib --examples --all-features --out xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biodivine-hctl-model-checker"
-version = "0.1.7"
+version = "0.2.0"
 authors = ["Ondřej Huvar <xhuvar@fi.muni.cz>", "Samuel Pastva <sam.pastva@gmail.com>"]
 edition = "2021"
 description = "Library for symbolic HCTL model checking on partially defined Boolean networks."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ biodivine-lib-bdd = ">=0.5.1, <1.0.0"
 biodivine-lib-param-bn = ">=0.4.5, <1.0.0"
 clap = { version = "4.1.4", features = ["derive"] }
 rand = "0.8.5"
-termcolor = "1.3.0"
+termcolor = "1.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ path = "src/bin/convert_aeon_to_bnet.rs"
 [dependencies]
 biodivine-lib-bdd = ">=0.5.1, <1.0.0"
 biodivine-lib-param-bn = ">=0.4.5, <1.0.0"
-clap = { version = "4.1.4", features = ["derive"] }
+clap = { version = "4.4.4", features = ["derive"] }
 rand = "0.8.5"
-termcolor = "1.1.2"
+termcolor = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ path = "src/bin/convert_aeon_to_bnet.rs"
 [dependencies]
 biodivine-lib-bdd = ">=0.5.1, <1.0.0"
 biodivine-lib-param-bn = ">=0.4.5, <1.0.0"
-clap = { version = "4.4.4", features = ["derive"] }
+clap = { version = "4.1.4", features = ["derive"] }
 rand = "0.8.5"
 termcolor = "1.3.0"

--- a/README.md
+++ b/README.md
@@ -85,3 +85,10 @@ The operator precedence is following (the lower, the stronger):
 * hybrid operators: 8
 
 However, it is strongly recommended to use parentheses wherever possible to prevent any parsing issues.
+
+#### Wild-card properties
+
+The library also provides functions to model check extended formulae that contain so called "wild-card properties".
+These special properties are evaluated as an arbitrary (coloured) set given by the user.
+This allows to re-use already pre-computed results in subsequent computations. 
+In formulae, the syntax of these properties is `%property_name%`.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This includes properties like stability, bi-stability, attractors, or oscillator
 To run the model checker, you will need the Rust compiler.
 We recommend following the instructions on [rustlang.org](https://www.rust-lang.org/learn/get-started).
 
+If you are not familiar with Rust, there are also Python bindings for most of the important functionality in [AEON.py](https://github.com/sybila/biodivine-aeon-py).
+
 ## Functionality
 
 This repository encompasses the CLI model-checking tool, and the model-checking library.
@@ -88,7 +90,7 @@ However, it is strongly recommended to use parentheses wherever possible to prev
 
 #### Wild-card properties
 
-The library also provides functions to model check extended formulae that contain so called "wild-card properties".
-These special properties are evaluated as an arbitrary (coloured) set given by the user.
-This allows to re-use already pre-computed results in subsequent computations. 
-In formulae, the syntax of these properties is `%property_name%`.
+The library also provides functions to model check extended formulae that contain so called "wild-card propositions".
+These special propositions are evaluated as an arbitrary (coloured) set given by the user.
+This allows the re-use of already pre-computed results in subsequent computations. 
+In formulae, the syntax of these propositions is `%property_name%`.

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -153,14 +153,13 @@ pub fn analyse_formula(
 
 #[cfg(test)]
 mod tests {
-    use crate::analysis::analyse_formulae;
+    use crate::analysis::{analyse_formula, analyse_formulae};
     use crate::result_print::PrintOptions;
     use biodivine_lib_param_bn::BooleanNetwork;
 
     #[test]
     /// Simple test to check whether the whole analysis runs without an error.
     fn test_analysis_run() {
-        let formulae = vec!["!{x}: AG EF {x}".to_string(), "!{x}: AF {x}".to_string()];
         let model = r"
                 $frs2:(!erk & fgfr)
                 fgfr -> frs2
@@ -176,6 +175,10 @@ mod tests {
         ";
         let bn = BooleanNetwork::try_from(model).unwrap();
 
+        let formulae = vec!["!{x}: AG EF {x}".to_string(), "!{x}: AF {x}".to_string()];
         assert!(analyse_formulae(&bn, formulae, PrintOptions::WithProgress).is_ok());
+
+        let formula = "erk & fgfr & frs2 & ~shc".to_string(); // simple to avoid long prints
+        assert!(analyse_formula(&bn, formula, PrintOptions::Exhaustive).is_ok());
     }
 }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,7 +1,7 @@
 //! Model-checking analysis from start to finish, with progress output and result prints.
 
 use crate::evaluation::algorithm::{compute_steady_states, eval_node};
-use crate::evaluation::eval_info::EvalInfo;
+use crate::evaluation::eval_info::EvalContext;
 use crate::mc_utils::{collect_unique_hctl_vars, get_extended_symbolic_graph};
 use crate::preprocessing::parser::parse_hctl_formula;
 use crate::preprocessing::utils::check_props_and_rename_vars;
@@ -9,7 +9,7 @@ use crate::result_print::*;
 
 use biodivine_lib_param_bn::BooleanNetwork;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::SystemTime;
 
 /// Perform the whole model checking analysis regarding several (individual) formulae. This
@@ -42,7 +42,7 @@ pub fn analyse_formulae(
         );
 
         let modified_tree = check_props_and_rename_vars(tree, HashMap::new(), String::new(), bn)?;
-        let num_hctl_vars = collect_unique_hctl_vars(modified_tree.clone(), HashSet::new()).len();
+        let num_hctl_vars = collect_unique_hctl_vars(modified_tree.clone()).len();
         print_if_allowed(
             format!("Modified version:     {}", modified_tree.subform_str),
             print_op,
@@ -86,7 +86,7 @@ pub fn analyse_formulae(
     print_if_allowed("-----".to_string(), print_op);
 
     // find duplicate sub-formulae throughout all formulae + initiate caching structures
-    let mut eval_info = EvalInfo::from_multiple_trees(&parsed_trees);
+    let mut eval_info = EvalContext::from_multiple_trees(&parsed_trees);
     print_if_allowed(
         format!(
             "Found following duplicate sub-formulae (canonized): {:?}",

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,7 +1,7 @@
 //! Model-checking analysis from start to finish, with progress output and result prints.
 
 use crate::evaluation::algorithm::{compute_steady_states, eval_node};
-use crate::evaluation::eval_info::EvalContext;
+use crate::evaluation::eval_context::EvalContext;
 use crate::mc_utils::{collect_unique_hctl_vars, get_extended_symbolic_graph};
 use crate::preprocessing::parser::parse_hctl_formula;
 use crate::preprocessing::utils::check_props_and_rename_vars;

--- a/src/evaluation/algorithm.rs
+++ b/src/evaluation/algorithm.rs
@@ -2,7 +2,7 @@
 
 use crate::aeon::scc_computation::compute_attractor_states;
 use crate::evaluation::canonization::get_canonical_and_mapping;
-use crate::evaluation::eval_info::EvalInfo;
+use crate::evaluation::eval_info::EvalContext;
 use crate::evaluation::hctl_operators_evaluation::*;
 use crate::evaluation::low_level_operations::substitute_hctl_var;
 use crate::preprocessing::node::{HctlTreeNode, NodeType};
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 pub fn eval_node(
     node: HctlTreeNode,
     graph: &SymbolicAsyncGraph,
-    eval_info: &mut EvalInfo,
+    eval_info: &mut EvalContext,
     steady_states: &GraphColoredVertices,
 ) -> GraphColoredVertices {
     // first check whether this node does not belong in the duplicates
@@ -89,6 +89,7 @@ pub fn eval_node(
             Atomic::False => graph.mk_empty_vertices(),
             Atomic::Var(name) => eval_hctl_var(graph, name.as_str()),
             Atomic::Prop(name) => eval_prop(graph, &name),
+            Atomic::WildCardProp(_) => todo!(),
         },
         NodeType::UnaryNode(op, child) => match op {
             UnaryOp::Not => eval_neg(graph, &eval_node(*child, graph, eval_info, steady_states)),
@@ -269,8 +270,8 @@ mod tests {
     #[test]
     /// Test recognition of fixed-point pattern.
     fn test_fixed_point_pattern() {
-        let tree = create_hybrid(
-            create_unary(create_var_node("x".to_string()), UnaryOp::Ax),
+        let tree = create_hybrid_node(
+            create_unary_node(create_var_node("x".to_string()), UnaryOp::Ax),
             "x".to_string(),
             HybridOp::Bind,
         );
@@ -280,9 +281,9 @@ mod tests {
     #[test]
     /// Test recognition of attractor pattern.
     fn test_attractor_pattern() {
-        let tree = create_hybrid(
-            create_unary(
-                create_unary(create_var_node("x".to_string()), UnaryOp::Ef),
+        let tree = create_hybrid_node(
+            create_unary_node(
+                create_unary_node(create_var_node("x".to_string()), UnaryOp::Ef),
                 UnaryOp::Ag,
             ),
             "x".to_string(),

--- a/src/evaluation/eval_context.rs
+++ b/src/evaluation/eval_context.rs
@@ -105,6 +105,9 @@ mod tests {
             EvalContext::from_multiple_trees(&vec![syntax_tree])
         );
         assert_eq!(eval_info.get_duplicates(), expected_duplicates);
+
+        // check that cache is always initially empty
+        assert!(eval_info.get_cache().is_empty());
     }
 
     #[test]

--- a/src/evaluation/eval_info.rs
+++ b/src/evaluation/eval_info.rs
@@ -11,60 +11,87 @@ use std::collections::HashMap;
 
 /// Struct holding information for efficient caching during the main computation.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EvalInfo {
+pub struct EvalContext {
     /// Duplicate sub-formulae and their counter
     pub duplicates: HashMap<String, i32>,
-    /// Cached sub-formulae and their result + variable renaming mapping
+    /// Cached sub-formulae and their result + corresponding mapping of variable renaming
     pub cache: HashMap<String, (GraphColoredVertices, HashMap<String, String>)>,
 }
 
-impl EvalInfo {
+impl EvalContext {
     /// Instantiate the struct with precomputed duplicates and empty cache.
-    pub fn new(duplicates: HashMap<String, i32>) -> EvalInfo {
-        EvalInfo {
+    pub fn new(duplicates: HashMap<String, i32>) -> EvalContext {
+        EvalContext {
             duplicates,
             cache: HashMap::new(),
         }
     }
 
     /// Instantiate the struct with precomputed duplicates and empty cache.
-    pub fn from_single_tree(tree: &HctlTreeNode) -> EvalInfo {
-        EvalInfo {
+    pub fn from_single_tree(tree: &HctlTreeNode) -> EvalContext {
+        EvalContext {
             duplicates: mark_duplicates_canonized_single(tree),
             cache: HashMap::new(),
         }
     }
 
     /// Instantiate the struct with precomputed duplicates and empty cache.
-    pub fn from_multiple_trees(trees: &Vec<HctlTreeNode>) -> EvalInfo {
-        EvalInfo {
+    pub fn from_multiple_trees(trees: &Vec<HctlTreeNode>) -> EvalContext {
+        EvalContext {
             duplicates: mark_duplicates_canonized_multiple(trees),
             cache: HashMap::new(),
         }
     }
 
+    /// Get the duplicates field containing the sub-formulae and their counter.
     pub fn get_duplicates(&self) -> HashMap<String, i32> {
         self.duplicates.clone()
+    }
+
+    /// Extend the standard evaluation context with "pre-computed cache" regarding wild-card nodes.
+    pub fn extend_context_with_wild_cards(
+        &mut self,
+        substitution_context: HashMap<String, GraphColoredVertices>
+    ) {
+        // For each `wild-card proposition` in `substitution_context`, increment its duplicate
+        // counter. That way, the first occurrence will also be treated as duplicate and taken from
+        // cache directly.
+        for (prop_name, raw_set) in substitution_context.into_iter() {
+            // we dont have to compute canonical sub-formula, because there are no HCTL variables
+            let sub_formula = format!("%{}%", prop_name);
+            if self.duplicates.contains_key(sub_formula.as_str()) {
+                self.duplicates.insert(
+                    sub_formula.clone(),
+                    self.duplicates[sub_formula.as_str()] + 1,
+                );
+            } else {
+                self.duplicates.insert(sub_formula.clone(), 1);
+            }
+
+            // Add the raw sets directly to the cache to be used during evaluation.
+            // The mapping for var renaming is empty, because there are no HCTL vars.
+            self.cache.insert(sub_formula, (raw_set, HashMap::new()));
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::evaluation::eval_info::EvalInfo;
+    use crate::evaluation::eval_info::EvalContext;
     use crate::preprocessing::parser::parse_hctl_formula;
     use std::collections::HashMap;
 
     #[test]
-    /// Test equivalent ways to generate EvalInfo object.
+    /// Test equivalent ways to generate EvalContext object.
     fn test_eval_info_creation() {
         let formula = "!{x}: (AX {x} & AX {x})".to_string();
         let syntax_tree = parse_hctl_formula(formula.as_str()).unwrap();
 
         let expected_duplicates = HashMap::from([("(Ax {var0})".to_string(), 1)]);
-        let eval_info = EvalInfo::new(expected_duplicates.clone());
+        let eval_info = EvalContext::new(expected_duplicates.clone());
 
-        assert_eq!(eval_info, EvalInfo::from_single_tree(&syntax_tree));
-        assert_eq!(eval_info, EvalInfo::from_multiple_trees(&vec![syntax_tree]));
+        assert_eq!(eval_info, EvalContext::from_single_tree(&syntax_tree));
+        assert_eq!(eval_info, EvalContext::from_multiple_trees(&vec![syntax_tree]));
         assert_eq!(eval_info.get_duplicates(), expected_duplicates);
     }
 }

--- a/src/evaluation/mod.rs
+++ b/src/evaluation/mod.rs
@@ -1,7 +1,7 @@
 //! Components regarding the evaluation of formulae, including the main model-checking algorithm.
 
 pub mod algorithm;
-pub mod eval_info;
+pub mod eval_context;
 pub mod mark_duplicate_subform;
 
 mod canonization;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 //! A small library regarding analysis of dynamic properties of Boolean networks through HCTL model checking.
 //! As of now, the library supports:
-//!  - Overall symbolic model-checking analysis of multiple HCTL formulae on a given model at once.
-//!  - Manipulation with HCTL formulae, such as tokenizing, parsing, or canonization.
+//!  - Model-checking analysis of HCTL properties on a (partially specified) BNs.
+//!  - Various formulae preprocessing utilities, such as tokenizing, parsing, or canonization.
+//!  - Manipulation with abstract syntactic trees for HCTL formulae.
 //!  - Searching for common sub-formulae across multiple formulae.
 //!  - Optimised evaluation for several patterns, such as various attractor types or reachability.
+//!  - Simultaneous evaluation of several formulae, sharing common computation via cache.
 //!
 
 pub mod analysis;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 //! A small library regarding analysis of dynamic properties of Boolean networks through HCTL model checking.
 //! As of now, the library supports:
 //!  - Model-checking analysis of HCTL properties on a (partially specified) BNs.
-//!  - Various formulae preprocessing utilities, such as tokenizing, parsing, or canonization.
+//!  - Various formulae preprocessing utilities, such as tokenizing, parsing, or some canonization.
 //!  - Manipulation with abstract syntactic trees for HCTL formulae.
-//!  - Searching for common sub-formulae across multiple formulae.
+//!  - Searching for common sub-formulae across multiple properties.
 //!  - Optimised evaluation for several patterns, such as various attractor types or reachability.
 //!  - Simultaneous evaluation of several formulae, sharing common computation via cache.
 //!

--- a/src/mc_utils.rs
+++ b/src/mc_utils.rs
@@ -38,11 +38,17 @@ fn collect_unique_hctl_vars_recursive(
     match formula_tree.node_type {
         NodeType::TerminalNode(_) => {}
         NodeType::UnaryNode(_, child) => {
-            seen_vars.extend(collect_unique_hctl_vars_recursive(*child, seen_vars.clone()));
+            seen_vars.extend(collect_unique_hctl_vars_recursive(
+                *child,
+                seen_vars.clone(),
+            ));
         }
         NodeType::BinaryNode(_, left, right) => {
             seen_vars.extend(collect_unique_hctl_vars_recursive(*left, seen_vars.clone()));
-            seen_vars.extend(collect_unique_hctl_vars_recursive(*right, seen_vars.clone()));
+            seen_vars.extend(collect_unique_hctl_vars_recursive(
+                *right,
+                seen_vars.clone(),
+            ));
         }
         // collect variables from exist and binder nodes
         NodeType::HybridNode(op, var_name, child) => {
@@ -52,7 +58,10 @@ fn collect_unique_hctl_vars_recursive(
                 }
                 _ => {}
             }
-            seen_vars.extend(collect_unique_hctl_vars_recursive(*child, seen_vars.clone()));
+            seen_vars.extend(collect_unique_hctl_vars_recursive(
+                *child,
+                seen_vars.clone(),
+            ));
         }
     }
     seen_vars
@@ -68,29 +77,42 @@ fn collect_unique_wild_card_props_recursive(
     mut seen_props: HashSet<String>,
 ) -> HashSet<String> {
     match formula_tree.node_type {
-        NodeType::TerminalNode(atom) => match atom {
-            Atomic::WildCardProp(prop_name) => {
+        NodeType::TerminalNode(atom) => {
+            if let Atomic::WildCardProp(prop_name) = atom {
                 seen_props.insert(prop_name);
             }
-            _ => {}
         }
         NodeType::UnaryNode(_, child) => {
-            seen_props.extend(collect_unique_wild_card_props_recursive(*child, seen_props.clone()));
+            seen_props.extend(collect_unique_wild_card_props_recursive(
+                *child,
+                seen_props.clone(),
+            ));
         }
         NodeType::BinaryNode(_, left, right) => {
-            seen_props.extend(collect_unique_wild_card_props_recursive(*left, seen_props.clone()));
-            seen_props.extend(collect_unique_wild_card_props_recursive(*right, seen_props.clone()));
+            seen_props.extend(collect_unique_wild_card_props_recursive(
+                *left,
+                seen_props.clone(),
+            ));
+            seen_props.extend(collect_unique_wild_card_props_recursive(
+                *right,
+                seen_props.clone(),
+            ));
         }
         NodeType::HybridNode(_, _, child) => {
-            seen_props.extend(collect_unique_wild_card_props_recursive(*child, seen_props.clone()));
+            seen_props.extend(collect_unique_wild_card_props_recursive(
+                *child,
+                seen_props.clone(),
+            ));
         }
     }
     seen_props
 }
 
-/// Check that extended symbolic graph's BDD supports enough extra variables for the computation.
+/// Check that extended symbolic graph's BDD supports enough extra variables for the evaluation of
+/// the formula given by a `hctl_syntactic_tree`.
 /// There must be `num_hctl_vars` extra symbolic BDD vars for each BN variable.
-pub fn check_hctl_var_support(stg: &SymbolicAsyncGraph, num_hctl_vars: usize) -> bool {
+pub fn check_hctl_var_support(stg: &SymbolicAsyncGraph, hctl_syntactic_tree: HctlTreeNode) -> bool {
+    let num_hctl_vars = collect_unique_hctl_vars(hctl_syntactic_tree).len();
     for bn_var in stg.as_network().variables() {
         if num_hctl_vars > stg.symbolic_context().extra_state_variables(bn_var).len() {
             return false;
@@ -101,8 +123,13 @@ pub fn check_hctl_var_support(stg: &SymbolicAsyncGraph, num_hctl_vars: usize) ->
 
 #[cfg(test)]
 mod tests {
-    use crate::mc_utils::collect_unique_hctl_vars;
-    use crate::preprocessing::parser::parse_hctl_formula;
+    use crate::mc_utils::{
+        check_hctl_var_support, collect_unique_hctl_vars, collect_unique_wild_card_props,
+        get_extended_symbolic_graph,
+    };
+    use crate::preprocessing::parser::{
+        parse_and_minimize_hctl_formula, parse_extended_formula, parse_hctl_formula,
+    };
     use crate::preprocessing::utils::check_props_and_rename_vars;
 
     use biodivine_lib_param_bn::BooleanNetwork;
@@ -110,25 +137,22 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     #[test]
-    /// Test regarding collecting state vars from HCTL formulae.
+    /// Test collecting state vars from HCTL formulae.
     fn test_state_var_collecting() {
-        // formula "FORKS1 & FORKS2" - both parts are semantically same, just use different var names
-        let formula = "(!{x}: 3{y}: (@{x}: ~{y} & (!{z}: AX {z})) & (@{y}: (!{z}: AX {z}))) & (!{x1}: 3{y1}: (@{x1}: ~{y1} & (!{z1}: AX {z1})) & (@{y1}: (!{z1}: AX {z1})))".to_string();
-        let tree = parse_hctl_formula(formula.as_str()).unwrap();
+        // conjunction of 2 formulae which are semantically same, just use different var names
+        let formula = "(!{x}: 3{y}: (@{x}: ~{y} & (!{z}: AX {z})) & (@{y}: (!{z}: AX {z}))) & (!{x1}: 3{y1}: (@{x1}: ~{y1} & (!{z1}: AX {z1})) & (@{y1}: (!{z1}: AX {z1})))";
+        let tree = parse_hctl_formula(formula).unwrap();
 
         // test for original tree
-        let expected_vars = vec![
+        let expected_vars = HashSet::from_iter(vec![
             "x".to_string(),
             "y".to_string(),
             "z".to_string(),
             "x1".to_string(),
             "y1".to_string(),
             "z1".to_string(),
-        ];
-        assert_eq!(
-            collect_unique_hctl_vars(tree.clone()),
-            HashSet::from_iter(expected_vars)
-        );
+        ]);
+        assert_eq!(collect_unique_hctl_vars(tree.clone()), expected_vars);
 
         // define any placeholder bn
         let bn = BooleanNetwork::try_from_bnet("v1, v1").unwrap();
@@ -136,10 +160,38 @@ mod tests {
         // and for tree with minimized number of renamed state vars
         let modified_tree =
             check_props_and_rename_vars(tree, HashMap::new(), String::new(), &bn).unwrap();
-        let expected_vars = vec!["x".to_string(), "xx".to_string(), "xxx".to_string()];
-        assert_eq!(
-            collect_unique_hctl_vars(modified_tree),
-            HashSet::from_iter(expected_vars)
-        );
+        let expected_vars =
+            HashSet::from_iter(vec!["x".to_string(), "xx".to_string(), "xxx".to_string()]);
+        assert_eq!(collect_unique_hctl_vars(modified_tree), expected_vars);
+    }
+
+    #[test]
+    /// Test collecting wild-card propositions from extended HCTL formulae.
+    fn test_wild_card_prop_collecting() {
+        let formula = "!{x}: 3{y}: (@{x}: ~{y} & %A% & %B%) & (@{y}: %A% & %C%)";
+        let tree = parse_extended_formula(formula).unwrap();
+
+        let expected_vars =
+            HashSet::from_iter(vec!["A".to_string(), "B".to_string(), "C".to_string()]);
+        assert_eq!(collect_unique_wild_card_props(tree.clone()), expected_vars);
+    }
+
+    #[test]
+    /// Test collecting wild-card propositions from extended HCTL formulae.
+    fn test_check_hctl_var_support() {
+        // define any placeholder bn and stg with enough variables
+        let bn = BooleanNetwork::try_from_bnet("v1, v1").unwrap();
+
+        // formula with 3 variables
+        let formula = "!{x}: 3{y}: (@{x}: ~{y} & (!{z}: AX {z})) & (@{y}: (!{z}: AX {z}))";
+        let tree = parse_and_minimize_hctl_formula(&bn, formula).unwrap();
+
+        // the stg that supports the same amount variables as the formula (3)
+        let stg = get_extended_symbolic_graph(&bn, 3).unwrap();
+        assert!(check_hctl_var_support(&stg, tree.clone()));
+
+        // the stg that supports less variables than the formula (1 vs 3)
+        let stg = get_extended_symbolic_graph(&bn, 1).unwrap();
+        assert!(!check_hctl_var_support(&stg, tree));
     }
 }

--- a/src/model_checking.rs
+++ b/src/model_checking.rs
@@ -412,6 +412,11 @@ $DivK: (!PleC & DivJ)
                 "(~(!{x}:AG EF{x})) AU (!{x}:AG EF{x})",
                 "~EG~(!{x}:AG EF{x}) & ~(~(!{x}:AG EF{x}) EU (~(!{x}:AG EF{x}) & (!{x}:AG EF{x})))",
             ),
+            // AU equivalence (where phi1 are fixed points, and phi2 the rest)
+            (
+                "(~(!{x}:AX{x})) AU (!{x}:AX{x})",
+                "~EG~(!{x}:AX{x}) & ~(~(!{x}:AX{x}) EU (~(!{x}:AX{x}) & (!{x}:AX{x})))",
+            ),
             // formulae for attractors, one is evaluated directly through optimisation
             ("!{x}: AG EF {x}", "!{x}: AG EF ({x} & {x})"),
             // formulae for fixed-points, one is evaluated directly through optimisation

--- a/src/model_checking.rs
+++ b/src/model_checking.rs
@@ -1,34 +1,43 @@
 //! High-level functionality regarding the whole model-checking process.
+//! Several variants of the model-checking procedure are provided:
+//!  - variants for both single or multiple formulae
+//!  - variants for formulae given by a string or a syntactic tree
+//!  - `dirty` variants that do not sanitize the resulting BDDs (and thus, the BDDs retain additional vars)
+//!  - variants allowing `extended` HCTL with special propositions referencing raw sets
+//!  - variants using potentially unsafe optimizations, targeted for specific use cases
 
 use crate::evaluation::algorithm::{compute_steady_states, eval_node};
-use crate::evaluation::eval_info::EvalContext;
+use crate::evaluation::eval_context::EvalContext;
 use crate::mc_utils::*;
 use crate::postprocessing::sanitizing::sanitize_colored_vertices;
 use crate::preprocessing::node::HctlTreeNode;
-use crate::preprocessing::parser::{parse_and_minimize_extended_formula, parse_and_minimize_hctl_formula};
+use crate::preprocessing::parser::{
+    parse_and_minimize_extended_formula, parse_and_minimize_hctl_formula,
+};
 
 use biodivine_lib_param_bn::symbolic_async_graph::{GraphColoredVertices, SymbolicAsyncGraph};
 use std::collections::HashMap;
 
-/// Perform the model checking for the list of HCTL syntax trees on GIVEN graph.
+/// Perform the model checking for the list of HCTL syntax trees on a given transition `graph`.
+/// The `graph` object MUST support enough symbolic variables to represent all occurring HCTL vars.
 /// Return the list of resulting sets of colored vertices (in the same order as input formulae).
-/// There MUST be enough symbolic variables to represent HCTL vars.
-/// Does not sanitize the resulting BDDs.
+///
+/// This version does not sanitize the resulting BDDs (`model_check_multiple_trees` does).
 pub fn model_check_multiple_trees_dirty(
     formula_trees: Vec<HctlTreeNode>,
-    stg: &SymbolicAsyncGraph,
+    graph: &SymbolicAsyncGraph,
 ) -> Result<Vec<GraphColoredVertices>, String> {
     // find duplicate sub-formulae throughout all formulae + initiate caching structures
     let mut eval_info = EvalContext::from_multiple_trees(&formula_trees);
     // pre-compute states with self-loops which will be needed during eval
-    let self_loop_states = compute_steady_states(stg);
+    let self_loop_states = compute_steady_states(graph);
 
     // evaluate the formulae (perform the actual model checking) and collect results
     let mut results: Vec<GraphColoredVertices> = Vec::new();
     for parse_tree in formula_trees {
         results.push(eval_node(
             parse_tree,
-            stg,
+            graph,
             &mut eval_info,
             &self_loop_states,
         ));
@@ -37,56 +46,56 @@ pub fn model_check_multiple_trees_dirty(
 }
 
 /// Perform the model checking for the syntactic tree, but do not sanitize the results.
+/// The `graph` object MUST support enough symbolic variables to represent all occurring HCTL vars.
 pub fn model_check_tree_dirty(
     formula_tree: HctlTreeNode,
-    stg: &SymbolicAsyncGraph,
+    graph: &SymbolicAsyncGraph,
 ) -> Result<GraphColoredVertices, String> {
-    let result = model_check_multiple_trees_dirty(vec![formula_tree], stg)?;
+    let result = model_check_multiple_trees_dirty(vec![formula_tree], graph)?;
     Ok(result[0].clone())
 }
 
-/// Perform the model checking for the list of HCTL syntax trees on GIVEN graph.
+/// Perform the model checking for the list of HCTL syntax trees on a given transition `graph`.
+/// The `graph` object MUST support enough symbolic variables to represent all occurring HCTL vars.
 /// Return the list of resulting sets of colored vertices (in the same order as input formulae).
-/// There MUST be enough symbolic variables to represent HCTL vars.
 pub fn model_check_trees(
     formula_trees: Vec<HctlTreeNode>,
-    stg: &SymbolicAsyncGraph,
+    graph: &SymbolicAsyncGraph,
 ) -> Result<Vec<GraphColoredVertices>, String> {
     // evaluate the formulae and collect results
-    let results = model_check_multiple_trees_dirty(formula_trees, stg)?;
+    let results = model_check_multiple_trees_dirty(formula_trees, graph)?;
 
     // sanitize the results' bdds - get rid of additional bdd vars used for HCTL vars
     let sanitized_results: Vec<GraphColoredVertices> = results
         .iter()
-        .map(|x| sanitize_colored_vertices(stg, x))
+        .map(|x| sanitize_colored_vertices(graph, x))
         .collect();
     Ok(sanitized_results)
 }
 
-/// Perform the model checking for a given HCTL syntax tree on GIVEN graph.
+/// Perform the model checking for a given HCTL formula's syntax tree on a given transition `graph`.
+/// The `graph` object MUST support enough symbolic variables to represent all occurring HCTL vars.
 /// Return the resulting set of colored vertices.
-/// There MUST be enough symbolic variables to represent all needed HCTL vars.
 pub fn model_check_tree(
     formula_tree: HctlTreeNode,
-    stg: &SymbolicAsyncGraph,
+    graph: &SymbolicAsyncGraph,
 ) -> Result<GraphColoredVertices, String> {
-    let result = model_check_trees(vec![formula_tree], stg)?;
+    let result = model_check_trees(vec![formula_tree], graph)?;
     Ok(result[0].clone())
 }
 
-/// Parse given formulae into syntactic trees and perform compatibility check with the provided STG.
+/// Parse given HCTL formulae into syntactic trees and perform compatibility check with
+/// the provided `graph` (i.e., check if `graph` object supports enough symbolic variables).
 fn parse_hctl_and_check(
     formulae: Vec<String>,
-    stg: &SymbolicAsyncGraph,
+    graph: &SymbolicAsyncGraph,
 ) -> Result<Vec<HctlTreeNode>, String> {
     // parse all the formulae and check that graph supports enough HCTL vars
     let mut parsed_trees = Vec::new();
     for formula in formulae {
-        let tree = parse_and_minimize_hctl_formula(stg.as_network(), formula.as_str())?;
-
+        let tree = parse_and_minimize_hctl_formula(graph.as_network(), formula.as_str())?;
         // check that given extended symbolic graph supports enough stated variables
-        let num_vars_formula = collect_unique_hctl_vars(tree.clone()).len();
-        if !check_hctl_var_support(stg, num_vars_formula) {
+        if !check_hctl_var_support(graph, tree.clone()) {
             return Err("Graph does not support enough HCTL state variables".to_string());
         }
         parsed_trees.push(tree);
@@ -94,66 +103,64 @@ fn parse_hctl_and_check(
     Ok(parsed_trees)
 }
 
-/// Perform the model checking for the list of formulae on GIVEN graph and return the list
-/// of resulting sets of colored vertices (in the same order as input formulae).
-/// Return Error if the given extended symbolic graph does not support enough extra BDD variables to
-/// represent all needed HCTL state-variables or if some formula is badly formed.
+/// Perform the model checking for the list of HCTL formulae on a given transition `graph`.
+/// Return the resulting sets of colored vertices (in the same order as input formulae).
+/// The `graph` object MUST support enough symbolic variables to represent all occurring HCTL vars.
 pub fn model_check_multiple_formulae(
     formulae: Vec<String>,
-    stg: &SymbolicAsyncGraph,
+    graph: &SymbolicAsyncGraph,
 ) -> Result<Vec<GraphColoredVertices>, String> {
     // get the abstract syntactic trees
-    let parsed_trees = parse_hctl_and_check(formulae, stg)?;
+    let parsed_trees = parse_hctl_and_check(formulae, graph)?;
     // run the main model-checking procedure on formulae trees
-    model_check_trees(parsed_trees, stg)
+    model_check_trees(parsed_trees, graph)
 }
 
 /// Perform the model checking for the list of formulae, but do not sanitize the results.
+/// The `graph` object MUST support enough symbolic variables to represent all occurring HCTL vars.
 pub fn model_check_multiple_formulae_dirty(
     formulae: Vec<String>,
-    stg: &SymbolicAsyncGraph,
+    graph: &SymbolicAsyncGraph,
 ) -> Result<Vec<GraphColoredVertices>, String> {
     // get the abstract syntactic trees
-    let parsed_trees = parse_hctl_and_check(formulae, stg)?;
+    let parsed_trees = parse_hctl_and_check(formulae, graph)?;
     // run the main model-checking procedure on formulae trees
-    model_check_multiple_trees_dirty(parsed_trees, stg)
+    model_check_multiple_trees_dirty(parsed_trees, graph)
 }
 
-/// Perform the model checking for given formula on GIVEN graph and return the resulting
-/// set of colored vertices.
-/// Return Error if the given extended symbolic graph does not support enough extra BDD variables
-/// to represent all needed HCTL state-variables or if the formula is badly formed.
+/// Perform the model checking for a given HCTL formula on a given transition `graph`.
+/// The `graph` object MUST support enough symbolic variables to represent all occurring HCTL vars.
+/// Return the resulting set of colored vertices.
 pub fn model_check_formula(
     formula: String,
-    stg: &SymbolicAsyncGraph,
+    graph: &SymbolicAsyncGraph,
 ) -> Result<GraphColoredVertices, String> {
-    let result = model_check_multiple_formulae(vec![formula], stg)?;
+    let result = model_check_multiple_formulae(vec![formula], graph)?;
     Ok(result[0].clone())
 }
 
 /// Perform the model checking for given formula, but do not sanitize the result.
+/// The `graph` object MUST support enough symbolic variables to represent all occurring HCTL vars.
 pub fn model_check_formula_dirty(
     formula: String,
-    stg: &SymbolicAsyncGraph,
+    graph: &SymbolicAsyncGraph,
 ) -> Result<GraphColoredVertices, String> {
-    let result = model_check_multiple_formulae_dirty(vec![formula], stg)?;
+    let result = model_check_multiple_formulae_dirty(vec![formula], graph)?;
     Ok(result[0].clone())
 }
 
-/// Parse given extended formulae into syntactic trees and perform compatibility check with the
-/// provided STG.
+/// Parse given extended HCTL formulae into syntactic trees and perform compatibility check with
+/// the provided `graph` (i.e., check if `graph` object supports enough symbolic variables).
 fn parse_extended_and_check(
     formulae: Vec<String>,
-    stg: &SymbolicAsyncGraph,
+    graph: &SymbolicAsyncGraph,
 ) -> Result<Vec<HctlTreeNode>, String> {
     // parse all the formulae and check that graph supports enough HCTL vars
     let mut parsed_trees = Vec::new();
     for formula in formulae {
-        let tree = parse_and_minimize_extended_formula(stg.as_network(), formula.as_str())?;
-
+        let tree = parse_and_minimize_extended_formula(graph.as_network(), formula.as_str())?;
         // check that given extended symbolic graph supports enough stated variables
-        let num_vars_formula = collect_unique_hctl_vars(tree.clone()).len();
-        if !check_hctl_var_support(stg, num_vars_formula) {
+        if !check_hctl_var_support(graph, tree.clone()) {
             return Err("Graph does not support enough HCTL state variables".to_string());
         }
         parsed_trees.push(tree);
@@ -161,7 +168,11 @@ fn parse_extended_and_check(
     Ok(parsed_trees)
 }
 
-/// todo: describe
+/// Perform the model checking for list of `extended` HCTL formulae on a given transition `graph`.
+/// Return the resulting sets of colored vertices (in the same order as input formulae).
+/// The `graph` object MUST support enough symbolic variables to represent all occurring HCTL vars.
+///
+/// The `substitution context` is a mapping determining how `wild-card propositions` are evaluated.
 pub fn model_check_multiple_extended_formulae(
     formulae: Vec<String>,
     stg: &SymbolicAsyncGraph,
@@ -198,9 +209,10 @@ pub fn model_check_multiple_extended_formulae(
     Ok(sanitized_results)
 }
 
-/// Perform the model checking for given extended formula on GIVEN graph and return the resulting
-/// set of colored vertices.
-/// The `substitution context` is a dictionary determining how `wild-card props` are evaluated.
+/// Perform the model checking for a given `extended` HCTL formula on a given transition `graph`.
+/// The `graph` object MUST support enough symbolic variables to represent all occurring HCTL vars.
+///
+/// The `substitution context` is a mapping determining how `wild-card propositions` are evaluated.
 pub fn model_check_extended_formula(
     formula: String,
     stg: &SymbolicAsyncGraph,
@@ -210,36 +222,36 @@ pub fn model_check_extended_formula(
     Ok(result[0].clone())
 }
 
-#[allow(dead_code)]
-/// Perform the model checking on GIVEN graph and return the resulting set of colored vertices.
-/// Self-loops are not pre-computed, and thus are ignored in EX computation, which is fine for
-/// some formulae, but incorrect for others - it is thus an UNSAFE optimisation - only use it
-/// if you are sure everything will work fine.
-/// This must NOT be used for formulae containing `!{x}:AX{x}` sub-formulae.
+/// Model check HCTL `formula` on a given transition `graph`.
+/// This version does not compute with self-loops. They are thus ignored in EX computation, which
+/// might fine for some formulae, but can be incorrect for others. It is an UNSAFE optimisation,
+/// only use it if you are sure everything will work fine.
+/// This function must NOT be used for formulae containing `!{x}:AX{x}` sub-formulae.
+///
 /// Also, this does not sanitize results.
 pub fn model_check_formula_unsafe_ex(
     formula: String,
-    stg: &SymbolicAsyncGraph,
+    graph: &SymbolicAsyncGraph,
 ) -> Result<GraphColoredVertices, String> {
-    let tree = parse_and_minimize_hctl_formula(stg.as_network(), formula.as_str())?;
-    // check that given extended symbolic graph supports enough stated variables
-    let num_vars_formula = collect_unique_hctl_vars(tree.clone()).len();
-    if !check_hctl_var_support(stg, num_vars_formula) {
+    let tree = parse_and_minimize_hctl_formula(graph.as_network(), formula.as_str())?;
+    // check that given extended symbolic graph supports enough symbolic variables
+    if !check_hctl_var_support(graph, tree.clone()) {
         return Err("Graph does not support enough HCTL state variables".to_string());
     }
 
     let mut eval_info = EvalContext::from_single_tree(&tree);
-
     // do not consider self-loops during EX computation (UNSAFE optimisation)
-    let result = eval_node(tree, stg, &mut eval_info, &stg.mk_empty_vertices());
+    let result = eval_node(tree, graph, &mut eval_info, &graph.mk_empty_vertices());
     Ok(result)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use crate::mc_utils::get_extended_symbolic_graph;
-    use crate::model_checking::{model_check_extended_formula, model_check_formula, model_check_formula_dirty};
+    use crate::model_checking::{
+        model_check_extended_formula, model_check_formula, model_check_formula_dirty,
+    };
+    use std::collections::HashMap;
 
     use biodivine_lib_param_bn::BooleanNetwork;
 
@@ -513,15 +525,47 @@ $DivK: (!PleC & DivJ)
         assert!(model_check_formula(formula, &stg).is_err());
     }
 
+    #[test]
+    /// Test evaluation of (very simple) extended formulae, where special propositions are
+    /// evaluated as various simple pre-computed sets.
+    fn test_model_check_extended_formulae_simple() {
+        let bn = BooleanNetwork::try_from(MODEL_ASYMMETRIC_CELL_DIVISION).unwrap();
+        let stg = get_extended_symbolic_graph(&bn, 1).unwrap();
+
+        // 1) first test, only proposition substituted
+        let formula_v1 = "PleC & EF PleC".to_string();
+        let sub_formula = "PleC".to_string();
+        let formula_v2 = "%s% & EF %s%".to_string();
+
+        let result_v1 = model_check_formula(formula_v1, &stg).unwrap();
+        // use 'dirty' version to avoid sanitation (for BDD to retain all symbolic vars)
+        let result_sub = model_check_formula_dirty(sub_formula, &stg).unwrap();
+        let context = HashMap::from([("s".to_string(), result_sub)]);
+        let result_v2 = model_check_extended_formula(formula_v2, &stg, context).unwrap();
+        assert!(result_v1.as_bdd().iff(result_v2.as_bdd()).is_true());
+
+        // 2) second test, disjunction substituted
+        let formula_v1 = "EX (PleC | DivK)".to_string();
+        let sub_formula = "PleC | DivK".to_string();
+        let formula_v2 = "EX %s%".to_string();
+
+        let result_v1 = model_check_formula(formula_v1, &stg).unwrap();
+        // use 'dirty' version to avoid sanitation (for BDD to retain all symbolic vars)
+        let result_sub = model_check_formula_dirty(sub_formula, &stg).unwrap();
+        let context = HashMap::from([("s".to_string(), result_sub)]);
+        let result_v2 = model_check_extended_formula(formula_v2, &stg, context).unwrap();
+        assert!(result_v1.as_bdd().iff(result_v2.as_bdd()).is_true());
+    }
+
     /// Test evaluation of extended HCTL formulae, in which `wild-card properties` can
     /// represent already pre-computed results.
     fn test_model_check_extended_formulae(bn: BooleanNetwork) {
         // test formulae use 3 HCTL vars at most
         let stg = get_extended_symbolic_graph(&bn, 3).unwrap();
 
-        // the test is conducted on 2 different formulae
+        // the test is conducted on two different formulae
 
-        // first define and evaluate the 2 formulae normally in one step
+        // first define and evaluate the two formulae normally in one step
         let formula1 = "!{x}: 3{y}: (@{x}: ~{y} & (!{z}: AX {z})) & (@{y}: (!{z}: AX {z}))";
         let formula2 = "3{x}: 3{y}: (@{x}: ~{y} & AX {x}) & (@{y}: AX {y}) & EF ({x} & (!{z}: AX {z})) & EF ({y} & (!{z}: AX {z})) & AX (EF ({x} & (!{z}: AX {z})) ^ EF ({y} & (!{z}: AX {z})))";
         let result1 = model_check_formula(formula1.to_string(), &stg).unwrap();
@@ -529,16 +573,26 @@ $DivK: (!PleC & DivJ)
 
         // now precompute part of the formula, and then substitute it as `wild-card proposition`
         let substitution_formula = "(!{z}: AX {z})";
-        // we must use 'dirty' version to avoid sanitation
+        // we must use 'dirty' version to avoid sanitation (BDDs must retain all symbolic vars)
         let raw_set = model_check_formula_dirty(substitution_formula.to_string(), &stg).unwrap();
-        let mut substitution_context = HashMap::new();
-        substitution_context.insert("subst".to_string(), raw_set);
+        let context = HashMap::from([("subst".to_string(), raw_set)]);
 
-        let formula1 = "!{x}: 3{y}: (@{x}: ~{y} & (!{z}: AX {z})) & (@{y}: %subst%)";
-        let formula2 = "3{x}: 3{y}: (@{x}: ~{y} & AX {x}) & (@{y}: AX {y}) & EF ({x} & %subst%) & EF ({y} & %subst%) & AX (EF ({x} & %subst%) ^ EF ({y} & %subst%))";
-        let result1_v2 = model_check_extended_formula(formula1.to_string(), &stg, substitution_context.clone()).unwrap();
-        let result2_v2 = model_check_extended_formula(formula2.to_string(), &stg, substitution_context).unwrap();
+        let formula1_v2 = "!{x}: 3{y}: (@{x}: ~{y} & %subst%) & (@{y}: %subst%)";
+        let formula2_v2 = "3{x}: 3{y}: (@{x}: ~{y} & AX {x}) & (@{y}: AX {y}) & EF ({x} & %subst%) & EF ({y} & %subst%) & AX (EF ({x} & %subst%) ^ EF ({y} & %subst%))";
+        let result1_v2 =
+            model_check_extended_formula(formula1_v2.to_string(), &stg, context.clone()).unwrap();
+        let result2_v2 =
+            model_check_extended_formula(formula2_v2.to_string(), &stg, context).unwrap();
 
+        assert!(result1.as_bdd().iff(result1_v2.as_bdd()).is_true());
+        assert!(result2.as_bdd().iff(result2_v2.as_bdd()).is_true());
+
+        // also double check that running "extended" evaluation on the original formula (without
+        // wild-card propositions) is the same as running the standard variant
+        let result1_v2 =
+            model_check_extended_formula(formula1.to_string(), &stg, HashMap::new()).unwrap();
+        let result2_v2 =
+            model_check_extended_formula(formula2.to_string(), &stg, HashMap::new()).unwrap();
         assert!(result1.as_bdd().iff(result1_v2.as_bdd()).is_true());
         assert!(result2.as_bdd().iff(result2_v2.as_bdd()).is_true());
     }

--- a/src/preprocessing/node.rs
+++ b/src/preprocessing/node.rs
@@ -137,3 +137,34 @@ impl fmt::Display for HctlTreeNode {
         write!(f, "{}", self.subform_str)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::preprocessing::node::HctlTreeNode;
+    use crate::preprocessing::tokenizer::{try_tokenize_extended_formula, try_tokenize_formula};
+
+    #[test]
+    /// Test creation, ordering, and display of HCTL tree nodes.
+    fn test_tree_nodes() {
+        // formula containing all kinds of operators and terminals (even wild-card propositions)
+        let formula1 = "!{x}: 3{y}: (@{x}: ~{y} & %subst% & True ^ v1)".to_string();
+        // much shorter formula to generate shallower tree
+        let formula2 = "!{x}: AX {x}".to_string();
+
+        // test `new` function works
+        let tokens1 = try_tokenize_extended_formula(formula1).unwrap();
+        let tokens2 = try_tokenize_formula(formula2).unwrap();
+        let node1 = HctlTreeNode::new(&tokens1).unwrap();
+        let node2 = HctlTreeNode::new(&tokens2).unwrap();
+
+        // higher tree should be greater
+        assert!(node1 > node2);
+        assert!(node2 <= node1);
+
+        // test display
+        let node1_str = "(Bind {x}: (Exists {y}: (Jump {x}: (((~ {y}) & (%subst% & True)) ^ v1))))";
+        let node2_str = "(Bind {x}: (Ax {x}))";
+        assert_eq!(node1.to_string(), node1_str.to_string());
+        assert_eq!(node2.to_string(), node2_str.to_string());
+    }
+}

--- a/src/preprocessing/node.rs
+++ b/src/preprocessing/node.rs
@@ -73,7 +73,7 @@ impl fmt::Display for HctlTreeNode {
 }
 
 /// Create a hybrid node from given arguments.
-pub fn create_hybrid(child: HctlTreeNode, var: String, op: HybridOp) -> HctlTreeNode {
+pub fn create_hybrid_node(child: HctlTreeNode, var: String, op: HybridOp) -> HctlTreeNode {
     HctlTreeNode {
         subform_str: format!("({} {{{}}}: {})", op, var, child.subform_str),
         height: child.height + 1,
@@ -82,7 +82,7 @@ pub fn create_hybrid(child: HctlTreeNode, var: String, op: HybridOp) -> HctlTree
 }
 
 /// Create an unary node from given arguments.
-pub fn create_unary(child: HctlTreeNode, op: UnaryOp) -> HctlTreeNode {
+pub fn create_unary_node(child: HctlTreeNode, op: UnaryOp) -> HctlTreeNode {
     HctlTreeNode {
         subform_str: format!("({} {})", op, child.subform_str),
         height: child.height + 1,
@@ -91,7 +91,7 @@ pub fn create_unary(child: HctlTreeNode, op: UnaryOp) -> HctlTreeNode {
 }
 
 /// Create a binary node from given arguments.
-pub fn create_binary(left: HctlTreeNode, right: HctlTreeNode, op: BinaryOp) -> HctlTreeNode {
+pub fn create_binary_node(left: HctlTreeNode, right: HctlTreeNode, op: BinaryOp) -> HctlTreeNode {
     HctlTreeNode {
         subform_str: format!("({} {} {})", left.subform_str, op, right.subform_str),
         height: cmp::max(left.height, right.height) + 1,
@@ -134,3 +134,13 @@ pub fn create_constant_node(constant_val: bool) -> HctlTreeNode {
         }
     }
 }
+
+/// Create a terminal `wild-card proposition` node from given arguments.
+pub fn create_wild_card_node(prop_name: String) -> HctlTreeNode {
+    HctlTreeNode {
+        subform_str: format!("%{prop_name}%"),
+        height: 0,
+        node_type: NodeType::TerminalNode(Atomic::WildCardProp(prop_name)),
+    }
+}
+

--- a/src/preprocessing/operator_enums.rs
+++ b/src/preprocessing/operator_enums.rs
@@ -38,12 +38,15 @@ pub enum HybridOp {
 }
 
 /// Enum for atomic sub-formulae - propositions, variables, and constants.
+/// There are also `wild-card propositions`, that will be directly evaluated as some precomputed
+/// coloured set. We have to differentiate them from classical propositions.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub enum Atomic {
-    Prop(String), // A proposition name
-    Var(String),  // A variable name
-    True,         // A true constant
-    False,        // A false constant
+    Prop(String),         // A proposition name
+    Var(String),          // A variable name
+    True,                 // A true constant
+    False,                // A false constant
+    WildCardProp(String), // A wild-card proposition name
 }
 
 impl fmt::Display for UnaryOp {
@@ -82,6 +85,7 @@ impl fmt::Display for Atomic {
             Atomic::Prop(name) => write!(f, "{name}"),
             Atomic::True => write!(f, "True"),
             Atomic::False => write!(f, "False"),
+            Atomic::WildCardProp(name) => write!(f, "%{name}%"),
         }
     }
 }

--- a/src/preprocessing/parser.rs
+++ b/src/preprocessing/parser.rs
@@ -299,14 +299,14 @@ mod tests {
         let tree = parse_hctl_formula(valid3).unwrap();
         assert_eq!(tree.subform_str, "(Exists {x}: (Exists {y}: ((Jump {x}: ((~ {y}) & (Ax {x}))) & ((Jump {y}: (Ax {y})) & ((Ef ({x} & (Bind {z}: (Ax {z})))) & ((Ef ({y} & (Bind {z}: (Ax {z})))) & (Ax ((Ef ({x} & (Bind {z}: (Ax {z})))) ^ (Ef ({y} & (Bind {z}: (Ax {z}))))))))))))".to_string());
 
-        // also test propositions and constants
+        // also test propositions, constants, and other operators (and their parse order)
         // propositions names should not be modified, constants should be unified to True/False
-        let valid4 = "(prop1 & PROP2 | false) AU (True & 0)";
+        let valid4 = "(prop1 <=> PROP2 | false => 1) AU (True ^ 0)";
         assert!(parse_hctl_formula(valid4).is_ok());
         let tree = parse_hctl_formula(valid4).unwrap();
         assert_eq!(
             tree.subform_str,
-            "(((prop1 & PROP2) | False) Au (True & False))".to_string()
+            "((prop1 <=> ((PROP2 | False) => True)) Au (True ^ False))".to_string()
         );
 
         // all formulae must be correctly parsed also using the extended version of HCTL

--- a/src/preprocessing/parser.rs
+++ b/src/preprocessing/parser.rs
@@ -9,7 +9,9 @@
 
 use crate::preprocessing::node::*;
 use crate::preprocessing::operator_enums::*;
-use crate::preprocessing::tokenizer::{try_tokenize_formula, HctlToken, try_tokenize_extended_formula};
+use crate::preprocessing::tokenizer::{
+    try_tokenize_extended_formula, try_tokenize_formula, HctlToken,
+};
 use crate::preprocessing::utils::check_props_and_rename_vars;
 
 use biodivine_lib_param_bn::BooleanNetwork;
@@ -59,7 +61,6 @@ pub fn parse_and_minimize_extended_formula(
     let tree = check_props_and_rename_vars(tree, HashMap::new(), String::new(), bn)?;
     Ok(tree)
 }
-
 
 /// Predicate for whether given token represents hybrid operator.
 fn is_hybrid(token: &HctlToken) -> bool {
@@ -122,10 +123,12 @@ fn parse_1_hybrid(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
             ));
         }
         match &tokens[i] {
-            HctlToken::Hybrid(op, var) => {
-                create_hybrid_node(parse_1_hybrid(&tokens[(i + 1)..])?, var.clone(), op.clone())
-            }
-            _ => HctlTreeNode::new(), // This branch cant happen, but must result in same type
+            HctlToken::Hybrid(op, var) => HctlTreeNode::mk_hybrid_node(
+                parse_1_hybrid(&tokens[(i + 1)..])?,
+                var.clone(),
+                op.clone(),
+            ),
+            _ => unreachable!(), // we already made sure that this is indeed a hybrid token
         }
     } else {
         parse_2_iff(tokens)?
@@ -136,7 +139,7 @@ fn parse_1_hybrid(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
 fn parse_2_iff(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
     let iff_token = index_of_first(tokens, HctlToken::Binary(BinaryOp::Iff));
     Ok(if let Some(i) = iff_token {
-        create_binary_node(
+        HctlTreeNode::mk_binary_node(
             parse_3_imp(&tokens[..i])?,
             parse_2_iff(&tokens[(i + 1)..])?,
             BinaryOp::Iff,
@@ -150,7 +153,7 @@ fn parse_2_iff(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
 fn parse_3_imp(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
     let imp_token = index_of_first(tokens, HctlToken::Binary(BinaryOp::Imp));
     Ok(if let Some(i) = imp_token {
-        create_binary_node(
+        HctlTreeNode::mk_binary_node(
             parse_4_or(&tokens[..i])?,
             parse_3_imp(&tokens[(i + 1)..])?,
             BinaryOp::Imp,
@@ -164,7 +167,7 @@ fn parse_3_imp(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
 fn parse_4_or(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
     let or_token = index_of_first(tokens, HctlToken::Binary(BinaryOp::Or));
     Ok(if let Some(i) = or_token {
-        create_binary_node(
+        HctlTreeNode::mk_binary_node(
             parse_5_xor(&tokens[..i])?,
             parse_4_or(&tokens[(i + 1)..])?,
             BinaryOp::Or,
@@ -178,7 +181,7 @@ fn parse_4_or(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
 fn parse_5_xor(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
     let xor_token = index_of_first(tokens, HctlToken::Binary(BinaryOp::Xor));
     Ok(if let Some(i) = xor_token {
-        create_binary_node(
+        HctlTreeNode::mk_binary_node(
             parse_6_and(&tokens[..i])?,
             parse_5_xor(&tokens[(i + 1)..])?,
             BinaryOp::Xor,
@@ -192,7 +195,7 @@ fn parse_5_xor(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
 fn parse_6_and(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
     let and_token = index_of_first(tokens, HctlToken::Binary(BinaryOp::And));
     Ok(if let Some(i) = and_token {
-        create_binary_node(
+        HctlTreeNode::mk_binary_node(
             parse_7_binary_temp(&tokens[..i])?,
             parse_6_and(&tokens[(i + 1)..])?,
             BinaryOp::And,
@@ -207,12 +210,12 @@ fn parse_7_binary_temp(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
     let binary_token = index_of_first_binary_temp(tokens);
     Ok(if let Some(i) = binary_token {
         match &tokens[i] {
-            HctlToken::Binary(op) => create_binary_node(
+            HctlToken::Binary(op) => HctlTreeNode::mk_binary_node(
                 parse_8_unary(&tokens[..i])?,
                 parse_7_binary_temp(&tokens[(i + 1)..])?,
                 op.clone(),
             ),
-            _ => HctlTreeNode::new(), // This branch cant happen, but must result in same type
+            _ => unreachable!(), // we already made sure that this is indeed a binary token
         }
     } else {
         parse_8_unary(tokens)?
@@ -224,8 +227,10 @@ fn parse_8_unary(tokens: &[HctlToken]) -> Result<HctlTreeNode, String> {
     let unary_token = index_of_first_unary(tokens);
     Ok(if let Some(i) = unary_token {
         match &tokens[i] {
-            HctlToken::Unary(op) => create_unary_node(parse_8_unary(&tokens[(i + 1)..])?, op.clone()),
-            _ => HctlTreeNode::new(), // This branch cant happen, but must result in same type
+            HctlToken::Unary(op) => {
+                HctlTreeNode::mk_unary_node(parse_8_unary(&tokens[(i + 1)..])?, op.clone())
+            }
+            _ => unreachable!(), // we already made sure that this is indeed an unary token
         }
     } else {
         parse_9_terminal_and_parentheses(tokens)?
@@ -243,15 +248,19 @@ fn parse_9_terminal_and_parentheses(tokens: &[HctlToken]) -> Result<HctlTreeNode
             match &tokens[0] {
                 HctlToken::Atom(Atomic::Prop(name)) => {
                     return if name == "true" || name == "True" || name == "1" {
-                        Ok(create_constant_node(true))
+                        Ok(HctlTreeNode::mk_constant_node(true))
                     } else if name == "false" || name == "False" || name == "0" {
-                        Ok(create_constant_node(false))
+                        Ok(HctlTreeNode::mk_constant_node(false))
                     } else {
-                        Ok(create_prop_node(name.clone()))
+                        Ok(HctlTreeNode::mk_prop_node(name.clone()))
                     }
                 }
-                HctlToken::Atom(Atomic::Var(name)) => return Ok(create_var_node(name.clone())),
-                HctlToken::Atom(Atomic::WildCardProp(name)) => return Ok(create_wild_card_node(name.clone())),
+                HctlToken::Atom(Atomic::Var(name)) => {
+                    return Ok(HctlTreeNode::mk_var_node(name.clone()))
+                }
+                HctlToken::Atom(Atomic::WildCardProp(name)) => {
+                    return Ok(HctlTreeNode::mk_wild_card_node(name.clone()))
+                }
                 // recursively solve sub-formulae in parentheses
                 HctlToken::Tokens(inner) => return parse_hctl_tokens(inner),
                 _ => {} // otherwise, fall through to the error at the end.
@@ -265,64 +274,70 @@ fn parse_9_terminal_and_parentheses(tokens: &[HctlToken]) -> Result<HctlTreeNode
 mod tests {
     use crate::preprocessing::node::*;
     use crate::preprocessing::operator_enums::*;
-    use crate::preprocessing::parser::parse_hctl_formula;
+    use crate::preprocessing::parser::{parse_extended_formula, parse_hctl_formula};
 
     #[test]
     /// Test whether several valid HCTL formulae are parsed without causing errors.
     /// Also check that the formula is saved correctly in the tree root.
     fn test_parse_valid_formulae() {
-        let valid1 = "!{x}: AG EF {x}".to_string();
-        assert!(parse_hctl_formula(valid1.as_str()).is_ok());
-        let tree = parse_hctl_formula(valid1.as_str()).unwrap();
+        let valid1 = "!{x}: AG EF {x}";
+        assert!(parse_hctl_formula(valid1).is_ok());
+        let tree = parse_hctl_formula(valid1).unwrap();
         assert_eq!(tree.subform_str, "(Bind {x}: (Ag (Ef {x})))".to_string());
 
-        let valid2 = "!{x}: 3{y}: (@{x}: ~{y} & AX {x}) & (@{y}: AX {y})".to_string();
-        assert!(parse_hctl_formula(valid2.as_str()).is_ok());
-        let tree = parse_hctl_formula(valid2.as_str()).unwrap();
+        let valid2 = "!{x}: 3{y}: (@{x}: ~{y} & AX {x}) & (@{y}: AX {y})";
+        assert!(parse_hctl_formula(valid2).is_ok());
+        let tree = parse_hctl_formula(valid2).unwrap();
         assert_eq!(
             tree.subform_str,
             "(Bind {x}: (Exists {y}: ((Jump {x}: ((~ {y}) & (Ax {x}))) & (Jump {y}: (Ax {y})))))"
                 .to_string()
         );
 
-        let valid3 = "3{x}: 3{y}: (@{x}: ~{y} & AX {x}) & (@{y}: AX {y}) & EF ({x} & (!{z}: AX {z})) & EF ({y} & (!{z}: AX {z})) & AX (EF ({x} & (!{z}: AX {z})) ^ EF ({y} & (!{z}: AX {z})))".to_string();
-        assert!(parse_hctl_formula(valid3.as_str()).is_ok());
-        let tree = parse_hctl_formula(valid3.as_str()).unwrap();
+        let valid3 = "3{x}: 3{y}: (@{x}: ~{y} & AX {x}) & (@{y}: AX {y}) & EF ({x} & (!{z}: AX {z})) & EF ({y} & (!{z}: AX {z})) & AX (EF ({x} & (!{z}: AX {z})) ^ EF ({y} & (!{z}: AX {z})))";
+        assert!(parse_hctl_formula(valid3).is_ok());
+        let tree = parse_hctl_formula(valid3).unwrap();
         assert_eq!(tree.subform_str, "(Exists {x}: (Exists {y}: ((Jump {x}: ((~ {y}) & (Ax {x}))) & ((Jump {y}: (Ax {y})) & ((Ef ({x} & (Bind {z}: (Ax {z})))) & ((Ef ({y} & (Bind {z}: (Ax {z})))) & (Ax ((Ef ({x} & (Bind {z}: (Ax {z})))) ^ (Ef ({y} & (Bind {z}: (Ax {z}))))))))))))".to_string());
 
         // also test propositions and constants
         // propositions names should not be modified, constants should be unified to True/False
-        let valid4 = "(prop1 & PROP2 | false) AU (True & 0)".to_string();
-        assert!(parse_hctl_formula(valid4.as_str()).is_ok());
-        let tree = parse_hctl_formula(valid4.as_str()).unwrap();
+        let valid4 = "(prop1 & PROP2 | false) AU (True & 0)";
+        assert!(parse_hctl_formula(valid4).is_ok());
+        let tree = parse_hctl_formula(valid4).unwrap();
         assert_eq!(
             tree.subform_str,
             "(((prop1 & PROP2) | False) Au (True & False))".to_string()
         );
+
+        // all formulae must be correctly parsed also using the extended version of HCTL
+        assert!(parse_extended_formula(valid1).is_ok());
+        assert!(parse_extended_formula(valid2).is_ok());
+        assert!(parse_extended_formula(valid3).is_ok());
+        assert!(parse_extended_formula(valid4).is_ok());
     }
 
     #[test]
     /// Test parsing of several valid HCTL formulae against expected results.
     fn compare_parser_with_expected() {
-        let formula = "(false & p1)".to_string();
-        let expected_tree = create_binary_node(
-            create_constant_node(false),
-            create_prop_node("p1".to_string()),
+        let formula = "(false & p1)";
+        let expected_tree = HctlTreeNode::mk_binary_node(
+            HctlTreeNode::mk_constant_node(false),
+            HctlTreeNode::mk_prop_node("p1".to_string()),
             BinaryOp::And,
         );
-        assert_eq!(parse_hctl_formula(formula.as_str()).unwrap(), expected_tree);
+        assert_eq!(parse_hctl_formula(formula).unwrap(), expected_tree);
 
-        let formula = "!{x}: (AX {x})".to_string();
-        let expected_tree = create_hybrid_node(
-            create_unary_node(create_var_node("x".to_string()), UnaryOp::Ax),
+        let formula = "!{x}: (AX {x})";
+        let expected_tree = HctlTreeNode::mk_hybrid_node(
+            HctlTreeNode::mk_unary_node(HctlTreeNode::mk_var_node("x".to_string()), UnaryOp::Ax),
             "x".to_string(),
             HybridOp::Bind,
         );
-        assert_eq!(parse_hctl_formula(formula.as_str()).unwrap(), expected_tree);
+        assert_eq!(parse_hctl_formula(formula).unwrap(), expected_tree);
     }
 
     #[test]
-    /// Test parsing of several invalid HCTL formulae.
+    /// Test parsing of several completely invalid HCTL formulae.
     fn test_parse_invalid_formulae() {
         let invalid_formulae = vec![
             "!{x}: AG EK {x}",
@@ -338,6 +353,31 @@ mod tests {
 
         for formula in invalid_formulae {
             assert!(parse_hctl_formula(formula).is_err());
+            // all formulae are invalid regardless if we allow for wild-card propositions
+            assert!(parse_extended_formula(formula).is_err());
         }
+    }
+
+    #[test]
+    /// Test parsing several extended HCTL formulae.
+    fn test_parse_extended_formulae() {
+        let formula = "(!{x}: AG EF {x}) & %p%";
+        // parser for standard HCTL should fail, for extended succeed
+        assert!(parse_hctl_formula(formula).is_err());
+        assert!(parse_extended_formula(formula).is_ok());
+        let tree = parse_extended_formula(formula).unwrap();
+        assert_eq!(
+            tree.subform_str,
+            "((Bind {x}: (Ag (Ef {x}))) & %p%)".to_string()
+        );
+
+        let formula = "!{x}: 3{y}: (@{x}: ~{y} & %s%) & (@{y}: %s%)";
+        assert!(parse_hctl_formula(formula).is_err());
+        assert!(parse_extended_formula(formula).is_ok());
+        let tree = parse_extended_formula(formula).unwrap();
+        assert_eq!(
+            tree.subform_str,
+            "(Bind {x}: (Exists {y}: ((Jump {x}: ((~ {y}) & %s%)) & (Jump {y}: %s%))))".to_string()
+        );
     }
 }

--- a/src/preprocessing/utils.rs
+++ b/src/preprocessing/utils.rs
@@ -28,7 +28,7 @@ pub fn check_props_and_rename_vars(
                     return Err(format!("Variable {name} is free."));
                 }
                 let renamed_var = mapping_dict.get(name.as_str()).unwrap();
-                Ok(create_var_node(renamed_var.to_string()))
+                Ok(HctlTreeNode::mk_var_node(renamed_var.to_string()))
             }
             Atomic::Prop(name) => {
                 // check that proposition corresponds to valid BN variable
@@ -45,7 +45,7 @@ pub fn check_props_and_rename_vars(
         NodeType::UnaryNode(op, child) => {
             let node =
                 check_props_and_rename_vars(*child, mapping_dict, last_used_name.clone(), bn)?;
-            Ok(create_unary_node(node, op))
+            Ok(HctlTreeNode::mk_unary_node(node, op))
         }
         // just dive deeper for binary nodes, and rename string
         NodeType::BinaryNode(op, left, right) => {
@@ -56,7 +56,7 @@ pub fn check_props_and_rename_vars(
                 bn,
             )?;
             let node2 = check_props_and_rename_vars(*right, mapping_dict, last_used_name, bn)?;
-            Ok(create_binary_node(node1, node2, op))
+            Ok(HctlTreeNode::mk_binary_node(node1, node2, op))
         }
         // hybrid nodes are more complicated
         NodeType::HybridNode(op, var, child) => {
@@ -86,29 +86,32 @@ pub fn check_props_and_rename_vars(
 
             // rename the variable in the node
             let renamed_var = mapping_dict.get(var.as_str()).unwrap();
-            Ok(create_hybrid_node(node, renamed_var.clone(), op))
+            Ok(HctlTreeNode::mk_hybrid_node(node, renamed_var.clone(), op))
         }
     };
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::preprocessing::parser::{parse_and_minimize_hctl_formula, parse_hctl_formula};
+    use crate::preprocessing::parser::{
+        parse_and_minimize_extended_formula, parse_and_minimize_hctl_formula,
+        parse_extended_formula, parse_hctl_formula,
+    };
     use crate::preprocessing::utils::check_props_and_rename_vars;
     use biodivine_lib_param_bn::BooleanNetwork;
     use std::collections::HashMap;
 
     /// Compare tree for formula with automatically minimized state var number to the
     /// tree for the semantically same, but already minimized formula.
-    fn test_state_var_minimization(formula: String, formula_minimized: String) {
+    fn test_state_var_minimization(formula: &str, formula_minimized: &str) {
         // define any placeholder bn
         let bn = BooleanNetwork::try_from_bnet("v1, v1").unwrap();
 
         // automatically modify the original formula via preprocessing step
-        let tree = parse_and_minimize_hctl_formula(&bn, formula.as_str()).unwrap();
+        let tree = parse_and_minimize_hctl_formula(&bn, formula).unwrap();
 
         // get expected tree using the (same) formula with already manually minimized vars
-        let tree_minimized = parse_hctl_formula(formula_minimized.as_str()).unwrap();
+        let tree_minimized = parse_hctl_formula(formula_minimized).unwrap();
 
         assert_eq!(tree_minimized, tree);
     }
@@ -117,24 +120,39 @@ mod tests {
     /// Test minimization of number of state variables and their renaming.
     fn test_state_var_minimization_simple() {
         let formula = "(!{x}: AG EF {x}) | (!{y}: !{x}: (AX {y} & AX {x})) | (!{z}: AG EF {z})";
-
         // same formula with already minimized vars
         let formula_minimized =
             "(!{x}: AG EF {x}) | (!{x}: !{xx}: (AX {x} & AX {xx})) | (!{x}: AG EF {x})";
 
-        test_state_var_minimization(formula.to_string(), formula_minimized.to_string());
+        test_state_var_minimization(formula, formula_minimized);
     }
 
     #[test]
     /// Test minimization of number of state variables and their renaming.
     fn test_state_var_minimization_complex() {
-        // formula "FORKS1 & FORKS2" - both parts are semantically same, just use different var names
+        // conjunction of two semantically same formulae (for FORK states) that use different var names
         let formula = "(!{x}: 3{y}: (@{x}: ~{y} & (!{z}: AX {z})) & (@{y}: (!{z}: AX {z}))) & (!{x1}: 3{y1}: (@{x1}: ~{y1} & (!{z1}: AX {z1})) & (@{y1}: (!{z1}: AX {z1})))";
-
         // same formula with already minimized vars
         let formula_minimized = "(!{x}: 3{xx}: (@{x}: ~{xx} & (!{xxx}: AX {xxx})) & (@{xx}: (!{xxx}: AX {xxx}))) & (!{x}: 3{xx}: (@{x}: ~{xx} & (!{xxx}: AX {xxx})) & (@{xx}: (!{xxx}: AX {xxx})))";
 
-        test_state_var_minimization(formula.to_string(), formula_minimized.to_string());
+        test_state_var_minimization(formula, formula_minimized);
+    }
+
+    #[test]
+    /// Test minimization of number of state variables and their renaming, but this time with
+    /// formula containing wild-card propositions (to check they are not affected).
+    fn test_state_var_minimization_with_wild_cards() {
+        // define any placeholder bn
+        let bn = BooleanNetwork::try_from_bnet("v1, v1").unwrap();
+
+        let formula = "!{x}: 3{y}: (@{x}: ~{y} & %subst%) & (@{y}: %subst%)";
+        // same formula with already minimized vars
+        let formula_minimized = "!{x}: 3{xx}: (@{x}: ~{xx} & %subst%) & (@{xx}: %subst%)";
+
+        let tree = parse_and_minimize_extended_formula(&bn, formula).unwrap();
+        // get expected tree using the (same) formula with already manually minimized vars
+        let tree_minimized = parse_extended_formula(formula_minimized).unwrap();
+        assert_eq!(tree_minimized, tree);
     }
 
     #[test]
@@ -144,8 +162,8 @@ mod tests {
         let bn = BooleanNetwork::try_from_bnet("v1, v1").unwrap();
 
         // define and parse formula with free variable
-        let formula = "AX {x}".to_string();
-        let tree = parse_hctl_formula(formula.as_str()).unwrap();
+        let formula = "AX {x}";
+        let tree = parse_hctl_formula(formula).unwrap();
 
         assert!(check_props_and_rename_vars(tree, HashMap::new(), String::new(), &bn).is_err());
     }
@@ -157,8 +175,8 @@ mod tests {
         let bn = BooleanNetwork::try_from_bnet("v1, v1").unwrap();
 
         // define and parse formula with two variables
-        let formula = "!{x}: !{x}: AX {x}".to_string();
-        let tree = parse_hctl_formula(formula.as_str()).unwrap();
+        let formula = "!{x}: !{x}: AX {x}";
+        let tree = parse_hctl_formula(formula).unwrap();
 
         assert!(check_props_and_rename_vars(tree, HashMap::new(), String::new(), &bn).is_err());
     }
@@ -170,8 +188,8 @@ mod tests {
         let bn = BooleanNetwork::try_from_bnet("v1, v1").unwrap();
 
         // define and parse formula with invalid proposition
-        let formula = "AX invalid_proposition".to_string();
-        let tree = parse_hctl_formula(formula.as_str()).unwrap();
+        let formula = "AX invalid_proposition";
+        let tree = parse_hctl_formula(formula).unwrap();
 
         assert!(check_props_and_rename_vars(tree, HashMap::new(), String::new(), &bn).is_err());
     }

--- a/src/preprocessing/utils.rs
+++ b/src/preprocessing/utils.rs
@@ -7,7 +7,7 @@ use biodivine_lib_param_bn::BooleanNetwork;
 
 use std::collections::HashMap;
 
-/// Checks that all vars in formula are quantified (exactly once) and props are valid.
+/// Checks that all vars in formula are quantified (exactly once) and props are valid BN variables.
 /// Renames hctl vars in the formula tree to canonical form - "x", "xx", ...
 /// Renames as many state-vars as possible to identical names, without changing the semantics.
 pub fn check_props_and_rename_vars(
@@ -38,14 +38,14 @@ pub fn check_props_and_rename_vars(
                 }
                 Ok(orig_node)
             }
-            // constants are always fine
+            // constants or wild-card propositions are always considered fine
             _ => return Ok(orig_node),
         },
         // just dive one level deeper for unary nodes, and rename string
         NodeType::UnaryNode(op, child) => {
             let node =
                 check_props_and_rename_vars(*child, mapping_dict, last_used_name.clone(), bn)?;
-            Ok(create_unary(node, op))
+            Ok(create_unary_node(node, op))
         }
         // just dive deeper for binary nodes, and rename string
         NodeType::BinaryNode(op, left, right) => {
@@ -56,7 +56,7 @@ pub fn check_props_and_rename_vars(
                 bn,
             )?;
             let node2 = check_props_and_rename_vars(*right, mapping_dict, last_used_name, bn)?;
-            Ok(create_binary(node1, node2, op))
+            Ok(create_binary_node(node1, node2, op))
         }
         // hybrid nodes are more complicated
         NodeType::HybridNode(op, var, child) => {
@@ -86,7 +86,7 @@ pub fn check_props_and_rename_vars(
 
             // rename the variable in the node
             let renamed_var = mapping_dict.get(var.as_str()).unwrap();
-            Ok(create_hybrid(node, renamed_var.clone(), op))
+            Ok(create_hybrid_node(node, renamed_var.clone(), op))
         }
     };
 }


### PR DESCRIPTION
In this pull request, we add support for "wild-card propositions" in HCTL formulae, as mentioned in #8.  These special propositions are evaluated as an arbitrary (coloured) set given by the user. This allows, for instance, the re-use of already pre-computed results in subsequent computations. In formulae, the syntax of these properties is `%property_name%`.
Note that the BDD representation of provided coloured sets (to which wild-card propositions are evaluated) must contain the same symbolic variables as the original extended STG.

For evaluating these "extended" formulae, use the new `model_check_extended_formula` or `model_check_multiple_extended_formulae` functions. Use `parse_extended_formula` or `parse_and_minimize_extended_formula` if you only intend to parse them or `try_tokenize_extended_formula` for tokenization. 

All the provided "raw sets" are saved in the cache from the beginning to allow for smooth evaluation. Thus, mostly the internal code for preprocessing and generating cache was affected.

Further, structs `HctlTreeNode` and `EvalContext` were extended with new functionality to simplify their generating. Lots of refactoring and test suite extending also happened.
